### PR TITLE
Added documentation for goal preemption on behavior trees

### DIFF
--- a/concepts/index.rst
+++ b/concepts/index.rst
@@ -73,10 +73,10 @@ Additionally, modeling choices like to shoot at the goal from the left, right, o
 With a BT, basic primitives like "kick" "walk" "go to ball" can be created and reused for many behaviors.
 More information can be found `in this book <https://arxiv.org/abs/1709.00084>`_.
 I **strongly** recommend reading chapters 1-3 to get a good understanding of the nomenclature and workflow.
-It should only take about 30 minutes. 
+It should only take about 30 minutes.
 
 For this project, we use `BehaviorTree CPP V3 <https://www.behaviortree.dev/>`_ as the behavior tree library.
-We create node plugins which can be constructed into a tree, inside the ``BT Navigato``.
+We create node plugins which can be constructed into a tree, inside the ``BT Navigator``.
 The node plugins are loaded into the BT and when the XML file of the tree is parsed, the registered names are associated.
 At this point, we can march through the behavior tree to navigate.
 
@@ -109,7 +109,7 @@ When the behavior tree ticks the corresponding BT node, it will call the action 
 The action server callback inside the server will call the chosen algorithm by its name (e.g. ``FollowPath``) that maps to a specific algorithm.
 This allows a user to abstract the algorithm used in the behavior tree to classes of algorithms.
 For instance, you can have ``N`` plugin controllers to follow paths, dock with charger, avoid dynamic obstacles, or interface with a tool.
-Having all of these plugins in the same server allows the user to make use of a single environmental representation object, which is costly to duplicate. 
+Having all of these plugins in the same server allows the user to make use of a single environmental representation object, which is costly to duplicate.
 
 For the recovery server, each of the recoveries also contains their own name, however, each plugin will also expose its own special action server.
 This is done because of the wide variety of recovery actions that may be created cannot have a single simple interface to share.
@@ -130,7 +130,7 @@ Planners
 The task of a planner is to compute a path to complete some objective function.
 The path can also be known as a route, depending on the nomenclature and algorithm selected.
 Two canonical examples are computing a plan to a goal (e.g. from current position to a goal) or complete coverage (e.g. plan to cover all free space).
-The planner will have access to a global environmental representation and sensor data buffered into it. 
+The planner will have access to a global environmental representation and sensor data buffered into it.
 Planners can be written to:
 
 - Compute shortest path
@@ -145,7 +145,7 @@ Controllers
 
 Controllers, also known as local planners in ROS1, are the way we follow the globally computed path or complete a local task.
 The controller will have access to a local environment representation to attempt to compute feasible control efforts for the base to follow.
-Many controller will project the robot forward in space and compute a locally feasible path at each update iteration. 
+Many controller will project the robot forward in space and compute a locally feasible path at each update iteration.
 Controllers can be written to:
 
 - Follow a path
@@ -169,7 +169,7 @@ Another example would be if the robot was stuck due to dynamic obstacles or poor
 Backing up or spinning in place, if permissible, allow the robot to move from a poor location into free space it may navigate successfully.
 
 Finally, in the case of a total failure, a recovery may be implemented to call an operators attention for help.
-This can be done with email, SMS, Slack, Matrix, etc. 
+This can be done with email, SMS, Slack, Matrix, etc.
 
 
 State Estimation
@@ -212,7 +212,7 @@ Odometry
 ========
 
 It is the role of the odometry system to provide the ``odom`` -> ``base_link`` transformation.
-Odometry can come from many sources including LIDAR, RADAR, wheel encoders, VIO, and IMUs. 
+Odometry can come from many sources including LIDAR, RADAR, wheel encoders, VIO, and IMUs.
 The goal of the odometry is to provide a smooth and continuous local frame based on robot motion.
 The global positioning system will update the transformation relative to the global frame to account for the odometric drift.
 

--- a/migration/Eloquent.rst
+++ b/migration/Eloquent.rst
@@ -33,19 +33,21 @@ DWB Contains new parameters as an update relative to the ROS1 updates, `see here
 Additionally, the controller and planner interfaces were updated to include a ``std::string name`` parameter on initialization.
 This was added to the interfaces to allow the plugins to know the namespace it should load its parameters in.
 E.g. for a controller to find the parameter ``FollowPath.max_vel_x``, it must be given its name, ``FollowPath`` to get this parameter.
-All plugins will be expected to look up parameters in the namespace of its given name. 
+All plugins will be expected to look up parameters in the namespace of its given name.
 
 New Plugins
 ***********
 
 Many new behavior tree nodes were added.
 These behavior tree nodes are now BT plugins and dynamically loadable at run-time using behavior tree cpp v3.
-See ``nav2_behavior_tree`` for a full listing, or :ref:`plugins` for the current list of behavior tree plugins and their descriptions. 
+The default behavior trees have been upgraded to stop the recovery behaviours and trigger a replanning when the navigation goal is preempted.
+See ``nav2_behavior_tree`` for a full listing, or :ref:`plugins` for the current list of behavior tree plugins and their descriptions.
 These plugins are set as default in the ``nav2_bt_navigator`` but may be overridden by the ``bt_plugins`` parameter to include your specific plugins.
 
 Original GitHub tickets:
 
 - `DistanceController <https://github.com/ros-planning/navigation2/pull/1699>`_
+- `GoalUpdatedCondition <https://github.com/ros-planning/navigation2/pull/1712>`_
 
 Map Server Re-Work
 ******************

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -42,10 +42,10 @@ Costmap Layers
 |                                |                        | sets of measurements             |
 +--------------------------------+------------------------+----------------------------------+
 
-.. _Voxel Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins
-.. _Static Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins
-.. _Inflation Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins
-.. _Obstacle Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins
+.. _Voxel Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/voxel_layer.cpp
+.. _Static Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/static_layer.cpp
+.. _Inflation Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/inflation_layer.cpp
+.. _Obstacle Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/obstacle_layer.cpp
 .. _Spatio-Temporal Voxel Layer: https://github.com/SteveMacenski/spatio_temporal_voxel_layer/
 .. _Non-Persistent Voxel Layer: https://github.com/SteveMacenski/nonpersistent_voxel_layer
 
@@ -107,7 +107,6 @@ Recoveries
 |                      |                        | or getting more sensor data      |
 +----------------------+------------------------+----------------------------------+
 
-.. _Rotate: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
 .. _Back Up: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
 .. _Spin: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
 .. _Wait: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
@@ -138,14 +137,14 @@ Behavior Tree Nodes
 | `Wait Action`_                             | Steve Macenski      | Calls wait recovery action       |
 +--------------------------------------------+---------------------+----------------------------------+
 
-.. _Back Up Action: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Clear Costmap Service: https://github.com/ros-planning/navigation2/blob/master/nav2_costmap_2d/src/clear_costmap_service.cpp
-.. _Compute Path to Pose Action: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Follow Path Action: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Navigate to Pose Action: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Reinitalize Global Localization Service: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Spin Action: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Wait Action: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
+.. _Back Up Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/back_up_action.cpp
+.. _Clear Costmap Service: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
+.. _Compute Path to Pose Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+.. _Follow Path Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+.. _Navigate to Pose Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+.. _Reinitalize Global Localization Service: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.cpp
+.. _Spin Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/spin_action.cpp
+.. _Wait Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/wait_action.cpp
 
 
 +------------------------------------+--------------------+------------------------+
@@ -153,6 +152,9 @@ Behavior Tree Nodes
 +====================================+====================+========================+
 | `Goal Reached Condition`_          | Carl Delsey        | Checks if goal is      |
 |                                    |                    | reached within tol.    |
++------------------------------------+--------------------+------------------------+
+| `Goal Updated Condition`_          |Aitor Miguel Blanco | Checks if goal is      |
+|                                    |                    | preempted.             |
 +------------------------------------+--------------------+------------------------+
 | `Initial Pose received Condition`_ | Carl Delsey        | Checks if initial pose |
 |                                    |                    | has been set           |
@@ -169,10 +171,11 @@ Behavior Tree Nodes
 |                                    |                    | calls.                 |
 +------------------------------------+--------------------+------------------------+
 
-.. _Goal Reached Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Initial Pose received Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Is Stuck Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Transform Available Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
+.. _Goal Reached Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+.. _Goal Updated Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
+.. _Initial Pose received Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.cpp
+.. _Is Stuck Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
+.. _Transform Available Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/transform_available_condition.cpp
 
 +--------------------------+-------------------+----------------------------------+
 | Decorator Plugin Name    |    Creator        |       Description                |
@@ -184,8 +187,8 @@ Behavior Tree Nodes
 |                          |                   | distance traveled by the robot   |
 +--------------------------+-------------------+----------------------------------+
 
-.. _Rate Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Distance Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
+.. _Rate Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
+.. _Distance Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/
 
 +-----------------------+------------------------+----------------------------------+
 | Control Plugin Name   |         Creator        |       Description                |
@@ -205,6 +208,6 @@ Behavior Tree Nodes
 |                       |                        | a result and move on to ``i+1``  |
 +-----------------------+------------------------+----------------------------------+
 
-.. _Pipeline Sequence: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Recovery: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Round Robin: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
+.. _Pipeline Sequence: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/control/pipeline_sequence.cpp
+.. _Recovery: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/control/recovery_node.cpp
+.. _Round Robin: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/control/round_robin_node.cpp


### PR DESCRIPTION
Signed-off-by: Aitor Miguel Blanco <aitormibl@gmail.com>

* Added new condition node to plugins index (navigation2 #[1712](https://github.com/ros-planning/navigation2/pull/1712)).
* Updated migration guide.
* Added new section for recommended tree structures in concepts, under Behavior Trees.

Other changes:
* Updated links in plugins index.
* Small typos and blank spaces at end of lines.