### PR TITLE
Add speed controller to plugin list and migration guide

### DIFF
--- a/migration/Eloquent.rst
+++ b/migration/Eloquent.rst
@@ -47,6 +47,7 @@ These plugins are set as default in the ``nav2_bt_navigator`` but may be overrid
 Original GitHub tickets:
 
 - `DistanceController <https://github.com/ros-planning/navigation2/pull/1699>`_
+- `SpeedController <https://github.com/ros-planning/navigation2/pull/1744>`_
 - `GoalUpdatedCondition <https://github.com/ros-planning/navigation2/pull/1712>`_
 
 Map Server Re-Work

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -186,9 +186,13 @@ Behavior Tree Nodes
 | `Distance Controller`_   | Sarthak Mittal    | Ticks child node based on the    |
 |                          |                   | distance traveled by the robot   |
 +--------------------------+-------------------+----------------------------------+
+| `Speed Controller`_      | Sarthak Mittal    | Throttles child node to a rate   |
+|                          |                   | based on current robot speed.    |
++--------------------------+-------------------+----------------------------------+
 
 .. _Rate Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
-.. _Distance Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/
+.. _Distance Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
+.. _Speed Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
 
 +-----------------------+------------------------+----------------------------------+
 | Control Plugin Name   |         Creator        |       Description                |


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

As per https://github.com/ros-planning/navigation2/pull/1744