### PR TITLE
Update index.rst

### DIFF
--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -173,7 +173,7 @@ We allow for you to pull the latest docker image from the master branch at any t
 
 .. code:: bash
 
-  sudo docker pull rosplanning/navigation2:latest
+  sudo docker pull rosplanning/navigation2:master.release
 
 !!!!
 


### PR DESCRIPTION
Updated the documentation for fixing the following issue: Docker Images not Building on Docker Hub #1824.
Changed the docker tag from 'latest' to 'master.release' since the 'latest' tag does not exist and 'master.release' is same as what we intended 'latest' to be.