### PR TITLE
Add info for 'plugin' parameter for plugin namespaces

### DIFF
--- a/configuration/packages/configuring-controller-server.rst
+++ b/configuration/packages/configuring-controller-server.rst
@@ -35,6 +35,20 @@ Parameters
   Description
     List of mapped names for controller plugins for processing requests and parameters.
 
+  Note
+    Each plugin namespace defined in this list needs to have a :code:`plugin` parameter defining the type of plugin to be loaded in the namespace.
+
+    Example:
+
+    .. code-block:: yaml
+
+        controller_server:
+          ros__parameters:
+            controller_plugins: ["FollowPath"]
+            FollowPath:
+              plugin: "dwb_core::DWBLocalPlanner"
+    ..
+
 :min_x_velocity_threshold:
 
   ============== =============================

--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -277,6 +277,24 @@ Costmap2D ROS Parameters
   Description
     List of mapped plugin names for parameter namespaces and names.
 
+  Note
+    Each plugin namespace defined in this list needs to have a :code:`plugin` parameter defining the type of plugin to be loaded in the namespace.
+
+    Example:
+
+    .. code-block:: yaml
+
+        local_costmap:
+          ros__parameters:
+            plugins: ["obstacle_layer", "voxel_layer", "inflation_layer"]
+            obstacle_layer:
+              plugin: "nav2_costmap_2d::ObstacleLayer"
+            voxel_layer:
+              plugin: "nav2_costmap_2d::VoxelLayer"
+            inflation_layer:
+              plugin: "nav2_costmap_2d::InflationLayer"
+    ..
+
 Default Plugins
 ***************
 

--- a/configuration/packages/configuring-planner-server.rst
+++ b/configuration/packages/configuring-planner-server.rst
@@ -24,6 +24,20 @@ Parameters
   Description
     List of Mapped plugin names for parameters and processing requests.
 
+  Note
+    Each plugin namespace defined in this list needs to have a :code:`plugin` parameter defining the type of plugin to be loaded in the namespace.
+
+    Example:
+
+    .. code-block:: yaml
+
+        planner_server:
+          ros__parameters:
+            planner_plugins: ["GridBased"]
+            GridBased:
+              plugin: "nav2_navfn_planner/NavfnPlanner"
+    ..
+
 :expected_planner_frequency:
 
   ============== ========

--- a/configuration/packages/configuring-recovery-server.rst
+++ b/configuration/packages/configuring-recovery-server.rst
@@ -92,6 +92,24 @@ Recovery Server Parameters
   Description
     List of plugin names to use, also matches action server names.
 
+  Note
+    Each plugin namespace defined in this list needs to have a :code:`plugin` parameter defining the type of plugin to be loaded in the namespace.
+
+    Example:
+
+    .. code-block:: yaml
+
+        recoveries_server:
+          ros__parameters:
+            recovery_plugins: ["spin", "backup", "wait"]
+            spin:
+              plugin: "nav2_recoveries/Spin"
+            backup:
+              plugin: "nav2_recoveries/BackUp"
+            wait:
+              plugin: "nav2_recoveries/Wait"
+    ..
+
 Default Plugins
 ***************
 


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

Adds small notes for server plugin namespace list parameters to provide info about the existence and usage of the `plugin` parameter for each plugin namespace.