### PR TITLE
Clarify "Getting Started" launch file change

### DIFF
--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -51,6 +51,14 @@ Running the Example
    .. code-block:: bash
 
       ros2 launch nav2_bringup tb3_simulation_launch.py
+   
+   .. note::
+
+      For ``ROS 2 Dashing Diademata`` or earlier, use
+      ``nav2_simulation_launch.py``.
+      However, it is highly recommended to use Navigation 2 with ``ROS 2
+      Eloquent Elusor`` or later for **massively** improved stablity and
+      feature completeness.
 
    This launch file will launch Navigation2 with the AMCL localizer in the
    ``turtlebot3_world`` world.

--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -56,9 +56,9 @@ Running the Example
 
       For ``ROS 2 Dashing Diademata`` or earlier, use
       ``nav2_simulation_launch.py``.
-      However, it is highly recommended to use Navigation 2 with ``ROS 2
-      Eloquent Elusor`` or later for **massively** improved stablity and
-      feature completeness.
+      However, it is recommended to use the most recent `ROS 2 LTS distribution
+      <https://ros.org/reps/rep-2000.html>`_  for improved stablity and feature
+      completeness.
 
    This launch file will launch Navigation2 with the AMCL localizer in the
    ``turtlebot3_world`` world.


### PR DESCRIPTION
The added note should help new users or ROS 2 Dashing users avoid issues with
the "Getting Started" launch file, and also explain preference for Eloquent
and later.

ros-planning/navigation2#1607
ros-planning/navigation2#1663
ros-planning/navigation.ros.org#9
ros-planning/navigation.ros.org#36