### PR TITLE
Added clarification on footprint parameter syntax

### DIFF
--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -44,7 +44,7 @@ Costmap2D ROS Parameters
   ============== =======
 
   Description
-    Ordered set of footprint points passed in as a string, must be closed set.
+    Ordered set of footprint points passed in as a string, must be closed set. For example, the following defines a square base with side lengths of 0.2 meters `footprint: "[ [0.1, 0.1], [0.1, -0.1], [-0.1, -0.1], [-0.1, 0.1] ]"`.
 
 :global_frame:
 

--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -40,11 +40,11 @@ Costmap2D ROS Parameters
   ============== =======
   Type           Default
   -------------- -------
-  vector<double> {}   
+  vector<double> "[]"   
   ============== =======
 
   Description
-    Ordered set of footprint points, must be closed set.
+    Ordered set of footprint points passed in as a string, must be closed set.
 
 :global_frame:
 


### PR DESCRIPTION
Related to https://github.com/ros-planning/navigation2/issues/1874