### PR TITLE
Switch Master references to Main as master-branch of nav2 is deleted

### DIFF
--- a/2020summerOfCode/projects/grid_maps.rst
+++ b/2020summerOfCode/projects/grid_maps.rst
@@ -19,7 +19,7 @@ This will involve porting code from ROS 1 to ROS 2, analyzing uses of the enviro
 
 **Project output requirements**
 
-- Grid Maps ported to ROS 2 and merged into the master ROS 2 branch
+- Grid Maps ported to ROS 2 and merged into the main ROS 2 branch
 - Defined plugin interfaces to replace costmap 2D with grid maps
 - Implementing low-level operations on top of grid_maps to replace the base costmap_2d object.
 - You will not be expected to reimplement the full sensor processing mechanics of costmap_2d.

--- a/2020summerOfCode/projects/testing.rst
+++ b/2020summerOfCode/projects/testing.rst
@@ -32,7 +32,7 @@ The ROS 2 Navigation Stack has had a focus on testing and reliability as a chara
 - `ROS <https://www.ros.org/>`_
 - `Gazebo Simulator <http://gazebosim.org/>`_
 - `Navigation2 <https://navigation.ros.org/>`_
-- `Navigation2 Repo System Tests <https://github.com/ros-planning/navigation2/tree/master/nav2_system_tests>`_
+- `Navigation2 Repo System Tests <https://github.com/ros-planning/navigation2/tree/main/nav2_system_tests>`_
 
 **Licensing**
 - All contributions will be under the Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -4,5 +4,10 @@ https://navigation.ros.org/
 This folder holds the source and configuration files used to generate the
 [Navigation2 documentation](https://navigation.ros.org) web site.
 
+Dependencies for Build: 
+* [Sphinx](https://www.sphinx-doc.org/en/master/usage/installation.html)
+* `sudo apt install python3-pip`
+* `pip3 install breathe==4.12.0 sphinx_rtd_theme sphinxcontrib-plantuml`
+
 Build the docs locally with `make html` and you'll find the built docs entry point in `_build/html/index.html`.
 

--- a/build_instructions/build_docs/build_troubleshooting_guide.rst
+++ b/build_instructions/build_docs/build_troubleshooting_guide.rst
@@ -11,7 +11,7 @@ Common Navigation2 Dependencies Build Failures
 * Make sure to run rosdep for the correct ROS 2 distribution.
   ``rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>``
 
-* Make sure that the ``setup.bash`` is sourced in the ROS 2 installation or ROS 2 master build workspace, if applicable. Check if you can run talker and listener nodes.
+* Make sure that the ``setup.bash`` is sourced in the ROS 2 installation or ROS 2 main build workspace, if applicable. Check if you can run talker and listener nodes.
 
 * Make sure that the ``setup.bash`` in ``nav2_depend_ws/install`` is sourced.
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -15,7 +15,7 @@ Build
 *****
 
 There are 3 ways to build Navigation2.
-Building for a specific released distribution (e.g. ``eloquent``, ``foxy``), build Navigation2 on master branch using a quickstart setup script, or building master branch manually.
+Building for a specific released distribution (e.g. ``eloquent``, ``foxy``), build Navigation2 on main branch using a quickstart setup script, or building main branch manually.
 
 .. rst-class:: content-collapse
 
@@ -48,7 +48,7 @@ Note: You need to change ``--rosdistro`` to the selected ROS 2 distribution name
 
 .. rst-class:: content-collapse
 
-Quickstart Build Master
+Quickstart Build  Main
 =======================
 
 Steps
@@ -62,7 +62,7 @@ Ensure there are no ROS environment variables set in your terminal or `.bashrc` 
 
   mkdir <directory_for_workspaces>
   cd <directory_for_workspaces>
-  wget https://raw.githubusercontent.com/ros-planning/navigation2/master/tools/initial_ros_setup.sh
+  wget https://raw.githubusercontent.com/ros-planning/navigation2/main/tools/initial_ros_setup.sh
   chmod a+x initial_ros_setup.sh
   ./initial_ros_setup.sh
 
@@ -88,17 +88,17 @@ The `initial_ros_setup.sh` accepts the following options:
 
 .. rst-class:: content-collapse
 
-Manually Build Master
+Manually Build  Main
 =====================
 
-Build ROS 2 Master
+Build ROS 2  Main
 ------------------
 
 .. warning::
 
-   When building ROS 2 from source, make sure that the `ros2.repos` file is from the `master` branch.
+   When building ROS 2 from source, make sure that the `ros2.repos` file is from the `main` branch.
 
-Build ROS 2 master using the `build instructions <https://index.ros.org/doc/ros2/Installation>`_ provided in the ROS 2 documentation.
+Build ROS 2 main using the `build instructions <https://index.ros.org/doc/ros2/Installation>`_ provided in the ROS 2 documentation.
 
 
 Build Navigation2 Dependencies
@@ -117,16 +117,16 @@ Then, use ``vcs`` to clone the repos and versions in it into a workspace.
   source ros2_ws/install/setup.bash
   mkdir -p ~/nav2_depend_ws/src
   cd ~/nav2_depend_ws
-  wget https://raw.githubusercontent.com/ros-planning/navigation2/master/tools/ros2_dependencies.repos
+  wget https://raw.githubusercontent.com/ros-planning/navigation2/main/tools/ros2_dependencies.repos
   vcs import src < ros2_dependencies.repos
   rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>
   colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
-Build Navigation2 Master
+Build Navigation2  Main
 ------------------------
 
-Finally, now that we have ROS 2 master and the necessary dependencies, we can now build Navigation2 master itself.
-We'll source the ``nav2_depend_ws``, which will also source the ROS 2 master build workspace packages, to build with dependencies.
+Finally, now that we have ROS 2 main and the necessary dependencies, we can now build Navigation2 main itself.
+We'll source the ``nav2_depend_ws``, which will also source the ROS 2 main build workspace packages, to build with dependencies.
 The rest of this should look familiar.
 
 .. code:: bash
@@ -134,7 +134,7 @@ The rest of this should look familiar.
   source ~/nav2_depend_ws/install/setup.bash
   mkdir -p ~/navigation2_ws/src
   cd ~/navigation2_ws/src
-  git clone https://github.com/ros-planning/navigation2.git --branch master
+  git clone https://github.com/ros-planning/navigation2.git --branch main
   cd ~/navigation2_ws
   rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>
   colcon build --symlink-install
@@ -171,11 +171,11 @@ Note: You may also need to configure your docker for DNS to work. See article he
 Using DockerHub Container
 =========================
 
-We allow for you to pull the latest docker image from the master branch at any time. As new releases and tags are made, docker containers on docker hub will be versioned as well to chose from.
+We allow for you to pull the latest docker image from the main branch at any time. As new releases and tags are made, docker containers on docker hub will be versioned as well to chose from.
 
 .. code:: bash
 
-  sudo docker pull rosplanning/navigation2:master.release
+  sudo docker pull rosplanning/navigation2:main.release
 
 !!!!
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -48,8 +48,8 @@ Note: You need to change ``--rosdistro`` to the selected ROS 2 distribution name
 
 .. rst-class:: content-collapse
 
-Quickstart Build  Main
-=======================
+Quickstart Build Main
+=====================
 
 Steps
 -----
@@ -88,11 +88,11 @@ The `initial_ros_setup.sh` accepts the following options:
 
 .. rst-class:: content-collapse
 
-Manually Build  Main
-=====================
+Manually Build Main
+===================
 
-Build ROS 2  Main
-------------------
+Build ROS 2 Main
+----------------
 
 .. warning::
 
@@ -122,8 +122,8 @@ Then, use ``vcs`` to clone the repos and versions in it into a workspace.
   rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>
   colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 
-Build Navigation2  Main
-------------------------
+Build Navigation2 Main
+----------------------
 
 Finally, now that we have ROS 2 main and the necessary dependencies, we can now build Navigation2 main itself.
 We'll source the ``nav2_depend_ws``, which will also source the ROS 2 main build workspace packages, to build with dependencies.

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -82,7 +82,7 @@ Options
 
 The `initial_ros_setup.sh` accepts the following options:
 
-- `--no-ros2` This skips downloading and building the ROS 2 release. Instead it uses the binary packages and ``setup.sh`` installed in ``/opt/ros/<ros2-distro>``
+- ``--no-ros2`` This skips downloading and building the ROS 2 release. Instead it uses the binary packages and ``setup.sh`` installed in ``/opt/ros/<ros2-distro>``
 - ``--download-only`` This skips the build steps
 
 

--- a/conf.py
+++ b/conf.py
@@ -190,4 +190,4 @@ breathe_default_project = "SOF Project"
 breathe_default_members = ('members', 'undoc-members', 'content-only')
 
 extlinks = {'projectfile':
-    ('https://github.com/ros-planning/navigation2/blob/master/%s', 'filepath ')}
+    ('https://github.com/ros-planning/navigation2/blob/main/%s', 'filepath ')}

--- a/configuration/packages/bt-plugins/actions/BackUp.rst
+++ b/configuration/packages/bt-plugins/actions/BackUp.rst
@@ -7,7 +7,7 @@ Invokes the BackUp ROS 2 action server, which causes the robot to back up by a s
 It performs an linear translation by a given distance.
 This is used in nav2 Behavior Trees as a recovery behavior. The nav2_recoveries_ module implements the BackUp action server.
 
-.. _nav2_recoveries: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries
+.. _nav2_recoveries: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries
 
 Input Ports
 ***********

--- a/configuration/packages/bt-plugins/actions/ComputePathToPose.rst
+++ b/configuration/packages/bt-plugins/actions/ComputePathToPose.rst
@@ -6,7 +6,7 @@ ComputePathToPose
 Invokes the ComputePathToPose ROS 2 action server, which is implemented by the nav2_planner_ module. 
 The server address can be remapped using the ``server_name`` input port.
 
-.. _nav2_planner: https://github.com/ros-planning/navigation2/tree/master/nav2_planner
+.. _nav2_planner: https://github.com/ros-planning/navigation2/tree/main/nav2_planner
 
 Input Ports
 -----------

--- a/configuration/packages/bt-plugins/actions/NavigateToPose.rst
+++ b/configuration/packages/bt-plugins/actions/NavigateToPose.rst
@@ -5,7 +5,7 @@ NavigateToPose
 
 Invokes the NavigateToPose ROS 2 action server, which is implemented by the bt_navigator_ module.
 
-.. _bt_navigator: https://github.com/ros-planning/navigation2/tree/master/nav2_bt_navigator
+.. _bt_navigator: https://github.com/ros-planning/navigation2/tree/main/nav2_bt_navigator
 
 Input Ports
 -----------

--- a/configuration/packages/bt-plugins/actions/Spin.rst
+++ b/configuration/packages/bt-plugins/actions/Spin.rst
@@ -7,7 +7,7 @@ Invokes the Spin ROS 2 action server, which is implemented by the nav2_recoverie
 It performs an in-place rotation by a given angle. 
 This action is used in nav2 Behavior Trees as a recovery behavior.
 
-.. _nav2_recoveries: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries
+.. _nav2_recoveries: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries
 
 Input Ports
 -----------

--- a/configuration/packages/bt-plugins/actions/Wait.rst
+++ b/configuration/packages/bt-plugins/actions/Wait.rst
@@ -6,7 +6,7 @@ Wait
 Invokes the Wait ROS 2 action server, which is implemented by the nav2_recoveries_ module. 
 This action is used in nav2 Behavior Trees as a recovery behavior.
 
-.. _nav2_recoveries: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries
+.. _nav2_recoveries: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries
 
 Input Ports
 -----------

--- a/configuration/packages/configuring-amcl.rst
+++ b/configuration/packages/configuring-amcl.rst
@@ -5,7 +5,7 @@ AMCL
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_amcl
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_amcl
 
 AMCL implements the server for taking a static map and localizing the robot within it using an Adaptive Monte-Carlo Localizer.
 

--- a/configuration/packages/configuring-bt-navigator.rst
+++ b/configuration/packages/configuring-bt-navigator.rst
@@ -5,7 +5,7 @@ Behavior-Tree Navigator
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_bt_navigator
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_bt_navigator
 
 The BT Navigator (Behavior Tree Navigator) module implements the NavigateToPose task interface. 
 It is a Behavior Tree-based implementation of navigation that is intended to allow for flexibility 

--- a/configuration/packages/configuring-bt-xml.rst
+++ b/configuration/packages/configuring-bt-xml.rst
@@ -5,7 +5,7 @@ Behavior Tree XML Nodes
 
 The nav2_behavior_tree_ package provides several navigation-specific nodes that are pre-registered and can be included in Behavior Trees.
 
-.. _nav2_behavior_tree: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree
+.. _nav2_behavior_tree: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree
 
 Check this introduction_ to learn how behavior trees work and the difference between actions, conditions, controls and decorators.
 

--- a/configuration/packages/configuring-controller-server.rst
+++ b/configuration/packages/configuring-controller-server.rst
@@ -5,7 +5,7 @@ Controller Server
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_controller
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_controller
 
 The Controller Server implements the server for handling the controller requests for the stack and host a map of plugin implementations.
 It will take in path and plugin names for controller, progress checker and goal checker to use and call the appropriate plugins.

--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -5,7 +5,7 @@ Costmap 2D
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_costmap_2d
 
 The Costmap 2D package implements a 2D grid-based costmap for environmental representations and a number of sensor processing plugins.
 It is used in the planner and controller servers for creating the space to check for collisions or higher cost areas to negotiate around. 

--- a/configuration/packages/configuring-lifecycle.rst
+++ b/configuration/packages/configuring-lifecycle.rst
@@ -5,7 +5,7 @@ Lifecycle Manager
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_lifecycle_manager
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_lifecycle_manager
 
 The Lifecycle Manager module implements the method for handling the lifecycle transition states for the stack in a deterministic way.
 It will take in a set of ordered nodes to transition one-by-one into the configurating and activate states to run the stack.

--- a/configuration/packages/configuring-map-server.rst
+++ b/configuration/packages/configuring-map-server.rst
@@ -5,7 +5,7 @@ Map Server / Saver
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_map_server
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_map_server
 
 The Map Server implements the server for handling the map load requests for the stack and host a map topic.
 It also implements a map saver server which will run in the background and save maps based on service requests. There exists a map saver CLI similar to ROS 1 as well for a single map save.

--- a/configuration/packages/configuring-navfn.rst
+++ b/configuration/packages/configuring-navfn.rst
@@ -5,7 +5,7 @@ NavFn Planner
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_navfn_planner
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_navfn_planner
 
 The Navfn Planner plugin implements a wavefront Dijkstra or A* expanded planner.
 

--- a/configuration/packages/configuring-planner-server.rst
+++ b/configuration/packages/configuring-planner-server.rst
@@ -5,7 +5,7 @@ Planner Server
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_planner
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_planner
 
 The Planner Server implements the server for handling the planner requests for the stack and host a map of plugin implementations.
 It will take in a goal and a planner plugin name to use and call the appropriate plugin to compute a path to the goal.

--- a/configuration/packages/configuring-recovery-server.rst
+++ b/configuration/packages/configuring-recovery-server.rst
@@ -5,7 +5,7 @@ Recovery Server
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries
 
 The Recovery Server implements the server for handling recovery requests and hosting a vector of plugins implementing various C++ recoveries.
 It is also possible to implement independent recovery servers for each custom recovery, but this server will allow multiple recoveries to share resources such as costmaps and TF buffers to lower incremental costs for new behaviors.

--- a/configuration/packages/configuring-waypoint-follower.rst
+++ b/configuration/packages/configuring-waypoint-follower.rst
@@ -5,7 +5,7 @@ Waypoint Follower
 
 Source code on Github_.
 
-.. _Github: https://github.com/ros-planning/navigation2/tree/master/nav2_waypoint_follower
+.. _Github: https://github.com/ros-planning/navigation2/tree/main/nav2_waypoint_follower
 
 The Waypoint Follower module implements a way of doing waypoint following using the NavigateToPose action server.
 It will take in a set of ordered waypoints to follow and then try to navigate to them in order.

--- a/migration/Eloquent.rst
+++ b/migration/Eloquent.rst
@@ -109,7 +109,7 @@ Map Server now has new ``map_io`` dynamic library. All functions saving/loading 
 
 ``map_loader`` was completely removed from ``nav2_util``. All its functionality already present in ``map_io``. Please use it in your code instead.
 
-Please refer to the `original GitHub ticket <https://github.com/ros-planning/navigation2/issues/1010>`_ and `Map Server README <https://github.com/ros-planning/navigation2/blob/master/nav2_map_server/README.md>`_ for more information.
+Please refer to the `original GitHub ticket <https://github.com/ros-planning/navigation2/issues/1010>`_ and `Map Server README <https://github.com/ros-planning/navigation2/blob/main/nav2_map_server/README.md>`_ for more information.
 
 
 New Particle Filter Messages

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -46,11 +46,11 @@ Costmap Layers
 |                                |                        | sets of measurements             |
 +--------------------------------+------------------------+----------------------------------+
 
-.. _Voxel Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/voxel_layer.cpp
-.. _Static Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/static_layer.cpp
-.. _Range Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/range_sensor_layer.cpp
-.. _Inflation Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/inflation_layer.cpp
-.. _Obstacle Layer: https://github.com/ros-planning/navigation2/tree/master/nav2_costmap_2d/plugins/obstacle_layer.cpp
+.. _Voxel Layer: https://github.com/ros-planning/navigation2/tree/main/nav2_costmap_2d/plugins/voxel_layer.cpp
+.. _Static Layer: https://github.com/ros-planning/navigation2/tree/main/nav2_costmap_2d/plugins/static_layer.cpp
+.. _Range Layer: https://github.com/ros-planning/navigation2/tree/main/nav2_costmap_2d/plugins/range_sensor_layer.cpp
+.. _Inflation Layer: https://github.com/ros-planning/navigation2/tree/main/nav2_costmap_2d/plugins/inflation_layer.cpp
+.. _Obstacle Layer: https://github.com/ros-planning/navigation2/tree/main/nav2_costmap_2d/plugins/obstacle_layer.cpp
 .. _Spatio-Temporal Voxel Layer: https://github.com/SteveMacenski/spatio_temporal_voxel_layer/
 .. _Non-Persistent Voxel Layer: https://github.com/SteveMacenski/nonpersistent_voxel_layer
 
@@ -69,7 +69,7 @@ Controllers
 |                          |                    | holonomic robots.                |
 +--------------------------+--------------------+----------------------------------+
 
-.. _DWB Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_dwb_controller
+.. _DWB Controller: https://github.com/ros-planning/navigation2/tree/main/nav2_dwb_controller
 .. _TEB Controller: https://github.com/rst-tu-dortmund/teb_local_planner
 
 Planners
@@ -84,7 +84,7 @@ Planners
 |                   |                                       | holonomic particle           |
 +-------------------+---------------------------------------+------------------------------+
 
-.. _NavFn Planner: https://github.com/ros-planning/navigation2/tree/master/nav2_navfn_planner
+.. _NavFn Planner: https://github.com/ros-planning/navigation2/tree/main/nav2_navfn_planner
 
 Recoveries
 ==========
@@ -112,10 +112,10 @@ Recoveries
 |                      |                        | or getting more sensor data      |
 +----------------------+------------------------+----------------------------------+
 
-.. _Back Up: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Spin: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Wait: https://github.com/ros-planning/navigation2/tree/master/nav2_recoveries/plugins
-.. _Clear Costmap: https://github.com/ros-planning/navigation2/blob/master/nav2_costmap_2d/src/clear_costmap_service.cpp
+.. _Back Up: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries/plugins
+.. _Spin: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries/plugins
+.. _Wait: https://github.com/ros-planning/navigation2/tree/main/nav2_recoveries/plugins
+.. _Clear Costmap: https://github.com/ros-planning/navigation2/blob/main/nav2_costmap_2d/src/clear_costmap_service.cpp
 
 Behavior Tree Nodes
 ===================
@@ -144,15 +144,15 @@ Behavior Tree Nodes
 | `Truncate Path`_                           | Francisco Martín    | Modifies a path making it shorter|
 +--------------------------------------------+---------------------+----------------------------------+
 
-.. _Back Up Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/back_up_action.cpp
-.. _Clear Costmap Service: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
-.. _Compute Path to Pose Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
-.. _Follow Path Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/follow_path_action.cpp
-.. _Navigate to Pose Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
-.. _Reinitalize Global Localization Service: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.cpp
-.. _Spin Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/spin_action.cpp
-.. _Wait Action: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/wait_action.cpp
-.. _Truncate Path: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/action/truncate_path_action.cpp
+.. _Back Up Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/back_up_action.cpp
+.. _Clear Costmap Service: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
+.. _Compute Path to Pose Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/compute_path_to_pose_action.cpp
+.. _Follow Path Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/follow_path_action.cpp
+.. _Navigate to Pose Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/navigate_to_pose_action.cpp
+.. _Reinitalize Global Localization Service: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/reinitialize_global_localization_service.cpp
+.. _Spin Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/spin_action.cpp
+.. _Wait Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/wait_action.cpp
+.. _Truncate Path: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/truncate_path_action.cpp
 
 
 +------------------------------------+--------------------+------------------------+
@@ -187,13 +187,13 @@ Behavior Tree Nodes
 |                                    |                    | passed.                |
 +------------------------------------+--------------------+------------------------+
 
-.. _Goal Reached Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
-.. _Goal Updated Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
-.. _Initial Pose received Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.cpp
-.. _Is Stuck Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
-.. _Transform Available Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/transform_available_condition.cpp
-.. _Distance Traveled Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/distance_traveled_condition.cpp
-.. _Time Expired Condition: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/condition/time_expired_condition.cpp
+.. _Goal Reached Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/goal_reached_condition.cpp
+.. _Goal Updated Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/goal_updated_condition.cpp
+.. _Initial Pose received Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/initial_pose_received_condition.cpp
+.. _Is Stuck Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/is_stuck_condition.cpp
+.. _Transform Available Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/transform_available_condition.cpp
+.. _Distance Traveled Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/distance_traveled_condition.cpp
+.. _Time Expired Condition: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/condition/time_expired_condition.cpp
 
 +--------------------------+-------------------+----------------------------------+
 | Decorator Plugin Name    |    Creator        |       Description                |
@@ -211,10 +211,10 @@ Behavior Tree Nodes
 |                          |                   | topic subscription.              |
 +--------------------------+-------------------+----------------------------------+
 
-.. _Rate Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
-.. _Distance Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
-.. _Speed Controller: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
-.. _Goal Updater: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
+.. _Rate Controller: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/decorator/rate_controller.cpp
+.. _Distance Controller: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/decorator/distance_controller.cpp
+.. _Speed Controller: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/decorator/speed_controller.cpp
+.. _Goal Updater: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/decorator/goal_updater_node.cpp
 
 +-----------------------+------------------------+----------------------------------+
 | Control Plugin Name   |         Creator        |       Description                |
@@ -234,6 +234,6 @@ Behavior Tree Nodes
 |                       |                        | a result and move on to ``i+1``  |
 +-----------------------+------------------------+----------------------------------+
 
-.. _Pipeline Sequence: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/control/pipeline_sequence.cpp
-.. _Recovery: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/control/recovery_node.cpp
-.. _Round Robin: https://github.com/ros-planning/navigation2/tree/master/nav2_behavior_tree/plugins/control/round_robin_node.cpp
+.. _Pipeline Sequence: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/control/pipeline_sequence.cpp
+.. _Recovery: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/control/recovery_node.cpp
+.. _Round Robin: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/control/round_robin_node.cpp

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -9,15 +9,15 @@
 
 .. _documentation repo: https://github.com/ros-planning/navigation.ros.org/doc
 
-.. _nav2_bringup pkg: https://github.com/ros-planning/navigation2/tree/master/nav2_bringup/bringup
+.. _nav2_bringup pkg: https://github.com/ros-planning/navigation2/tree/main/nav2_bringup/bringup
 
-.. _nav2_params file: https://github.com/ros-planning/navigation2/blob/master/nav2_bringup/bringup/params/nav2_params.yaml
+.. _nav2_params file: https://github.com/ros-planning/navigation2/blob/main/nav2_bringup/bringup/params/nav2_params.yaml
 
 .. _documentation site: https://rosplanning.github.io/navigation.ros.org/
 
 .. _project website: https://rosplanning.github.io/navigation2/
 
-.. |PP| replace:: https://github.com/ros-planning/navigation2/blob/master
+.. |PP| replace:: https://github.com/ros-planning/navigation2/blob/main
 
 .. _`ROS 2 binary packages`: https://index.ros.org/doc/ros2/Installation/
 

--- a/tutorials/docs/navigation2_on_real_turtlebot3.rst
+++ b/tutorials/docs/navigation2_on_real_turtlebot3.rst
@@ -54,7 +54,7 @@ You will need to launch your robot's interface,
 You need to have a map of the environment where you want to Navigate Turtlebot 3, or create one live with SLAM.
 
 In case you are interested, there is a use case tutorial which shows how to use Navigation2 with SLAM.
-`Navigation2 with SLAM <https://github.com/ros-planning/navigation2/blob/master/doc/use_cases/navigation_with_slam.md>`_
+`Navigation2 with SLAM <https://github.com/ros-planning/navigation2/blob/main/doc/use_cases/navigation_with_slam.md>`_
 
 Required files:
 


### PR DESCRIPTION
Open questions: 
* Is Ros2 already on Main? (first 2 commits) - but only text
* ClearCostmap has some Master references that must be changed before docs change (master_grid)

+ adding dependency instructions for this README
+ small fix displaying ``--no-ros2`` correctly


 Did build successfully on my machine.