### PR TITLE
Update index.rst

### DIFF
--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -10,6 +10,10 @@ Navigation2 and its dependencies are released as binaries.
 You may install it via the following to get the latest stable released version:
 
   ``sudo apt install ros-<distro>-navigation2 ros-<distro>-nav2-bringup ros-<distro>-turtlebot3*``
+(For Ubuntu 20.04 use this command as the parsing of wildcards have been changed:
+
+  ``sudo apt install ros-<distro>-navigation2 ros-<distro>-nav2-bringup '~ros-<distro>-turtlebot3-.*'``
+ 
 
 Build
 *****


### PR DESCRIPTION
apt on Ubuntu 20.04 does not accept simple wildcard-characters anymore, but 

who@bla:~$ sudo apt install ros-foxy-navigation2 ros-foxy-nav2-bringup 'ros-foxy-turtlebot3-.***** ' 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
E: Unable to locate package ros-foxy-turtlebot3-.*