### PR TITLE
way point task executor; fix unintended table in Navigation plugins page

### DIFF
--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -278,6 +278,6 @@ Behavior Tree Nodes
 |                                 |                        | specific tasks to be executed on |
 |                                 |                        | waypoint arrivals.               |
 |                                 |                        |                                  |            
-+---------------------------------+----------------------------------+------------------------+
++---------------------------------+------------------------+----------------------------------+
 
 .. _Waypoint Task Executor: https://github.com/ros-planning/navigation2/tree/main/nav2_waypoint_follower/plugins/wait_at_waypoint.cpp


### PR DESCRIPTION
Signed-off-by: jediofgever <fetulahatas1@gmail.com>

In Navigation plugin [page](https://navigation.ros.org/plugins/index.html),   
 waypoint task executor table had indent error as below; ,

![Screenshot from 2020-10-09 12-42-44](https://user-images.githubusercontent.com/18460336/95544229-18c06480-0a2d-11eb-9a61-a6b450d940a8.png)

 the commit intents to fix that