### PR TITLE
Documentation changes for ray tracing param changes

### DIFF
--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -357,7 +357,8 @@ Example
             scan:
               topic: /scan
               obstacle_range: 2.5
-              raytrace_range: 3.0
+              raytrace_max_range: 3.0
+              raytrace_min_range: 0.0
               max_obstacle_height: 2.0
               min_obstacle_height: 0.0
               clearing: True
@@ -383,7 +384,8 @@ Example
               max_obstacle_height: 2.0
               min_obstacle_height: 0.0
               obstacle_range: 2.5
-              raytrace_range: 3.0
+              raytrace_max_range: 3.0
+              raytrace_min_range: 0.0
               clearing: True
               marking: True
               data_type: "PointCloud2"

--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -356,7 +356,8 @@ Example
             combination_method: 1
             scan:
               topic: /scan
-              obstacle_range: 2.5
+              obstacle_max_range: 2.5
+              obstacle_min_range: 0.0
               raytrace_max_range: 3.0
               raytrace_min_range: 0.0
               max_obstacle_height: 2.0
@@ -383,7 +384,8 @@ Example
               topic: /intel_realsense_r200_depth/points
               max_obstacle_height: 2.0
               min_obstacle_height: 0.0
-              obstacle_range: 2.5
+              obstacle_max_range: 2.5
+              obstacle_min_range: 0.0
               raytrace_max_range: 3.0
               raytrace_min_range: 0.0
               clearing: True

--- a/configuration/packages/costmap-plugins/obstacle.rst
+++ b/configuration/packages/costmap-plugins/obstacle.rst
@@ -172,7 +172,7 @@ Obstacle Layer Parameters
   Description
     Whether source should raytrace clear in costmap.
 
-:``<obstacle layer>``. ``<data source>``.obstacle_range:
+:``<obstacle layer>``. ``<data source>``.obstacle_max_range:
 
   ====== =======
   Type   Default                                                   
@@ -182,6 +182,17 @@ Obstacle Layer Parameters
 
   Description
     Maximum range to mark obstacles in costmap.
+
+:``<obstacle layer>``. ``<data source>``.obstacle_min_range:
+
+  ====== =======
+  Type   Default                                                   
+  ------ -------
+  double 0.0           
+  ====== =======
+
+  Description
+    Minimum range to mark obstacles in costmap.
 
 :``<obstacle layer>``. ``<data source>``.raytrace_max_range:
 

--- a/configuration/packages/costmap-plugins/obstacle.rst
+++ b/configuration/packages/costmap-plugins/obstacle.rst
@@ -183,7 +183,7 @@ Obstacle Layer Parameters
   Description
     Maximum range to mark obstacles in costmap.
 
-:``<obstacle layer>``. ``<data source>``.raytrace_range:
+:``<obstacle layer>``. ``<data source>``.raytrace_max_range:
 
   ====== =======
   Type   Default                                                   
@@ -193,3 +193,14 @@ Obstacle Layer Parameters
 
   Description
     Maximum range to raytrace clear obstacles from costmap.
+
+:``<obstacle layer>``. ``<data source>``.raytrace_min_range:
+
+  ====== =======
+  Type   Default                                                   
+  ------ -------
+  double 0.0            
+  ====== =======
+
+  Description
+    Minimum range to raytrace clear obstacles from costmap.

--- a/configuration/packages/costmap-plugins/voxel.rst
+++ b/configuration/packages/costmap-plugins/voxel.rst
@@ -249,7 +249,7 @@ Voxel Layer Parameters
   Description
     Maximum range to mark obstacles in costmap.
 
-:``<voxel layer>``. ``<data source>``.raytrace_range:
+:``<voxel layer>``. ``<data source>``.raytrace_max_range:
 
   ====== =======
   Type   Default                                                   
@@ -259,3 +259,14 @@ Voxel Layer Parameters
 
   Description
     Maximum range to raytrace clear obstacles from costmap.
+
+:``<voxel layer>``. ``<data source>``.raytrace_min_range:
+
+  ====== =======
+  Type   Default                                                   
+  ------ -------
+  double 0.0            
+  ====== =======
+
+  Description
+    Minimum range to raytrace clear obstacles from costmap.

--- a/configuration/packages/costmap-plugins/voxel.rst
+++ b/configuration/packages/costmap-plugins/voxel.rst
@@ -238,7 +238,7 @@ Voxel Layer Parameters
   Description
     Whether source should raytrace clear in costmap.
 
-:``<voxel layer>``. ``<data source>``.obstacle_range:
+:``<voxel layer>``. ``<data source>``.obstacle_max_range:
 
   ====== =======
   Type   Default                                                   
@@ -248,6 +248,17 @@ Voxel Layer Parameters
 
   Description
     Maximum range to mark obstacles in costmap.
+
+:``<voxel layer>``. ``<data source>``.obstacle_min_range:
+
+  ====== =======
+  Type   Default                                                   
+  ------ -------
+  double 0.0           
+  ====== =======
+
+  Description
+    Minimum range to mark obstacles in costmap.
 
 :``<voxel layer>``. ``<data source>``.raytrace_max_range:
 

--- a/migration/Foxy.rst
+++ b/migration/Foxy.rst
@@ -113,7 +113,7 @@ To follow the SI units outlined in REP-103 to the "T" nodes below were modified 
 
 Ray Tracing Parameters
 **********************
-Raytracing functionality was modified to include a minimum range parameter from which ray tracing starts to clear obstacles to avoid incorrectly clearing obstacles too close to the robot. This issue was mentioned in `ROS Answers <https://answers.ros.org/question/355150/obstacles-in-sensor-deadzone/>`_. An existing parameter `raytrace_range` was renamed to `raytrace_max_range` to reflect the functionality it affects. The renamed parameters and the plugins that they belong to are mentioned below. The changes were introduced in this `pull request <https://github.com/ros-planning/navigation2/pull/2126>`_.
+Raytracing functionality was modified to include a minimum range parameter from which ray tracing starts to clear obstacles to avoid incorrectly clearing obstacles too close to the robot. This issue was mentioned in `ROS Answers <https://answers.ros.org/question/355150/obstacles-in-sensor-deadzone/>`_. An existing parameter ``raytrace_range`` was renamed to ``raytrace_max_range`` to reflect the functionality it affects. The renamed parameters and the plugins that they belong to are mentioned below. The changes were introduced in this `pull request <https://github.com/ros-planning/navigation2/pull/2126>`_.
 
 - obstacle_layer plugin
  - ``raytrace_min_range`` controls the minimum range from which ray tracing clears obstacles from the costmap

--- a/migration/Foxy.rst
+++ b/migration/Foxy.rst
@@ -109,3 +109,15 @@ To follow the SI units outlined in REP-103 to the "T" nodes below were modified 
  - ``max_planning_time_ms`` became ``max_planning_time`` in seconds
 - map saver
  - ``save_map_timeout`` in seconds
+
+
+Ray Tracing Parameters
+**********************
+Raytracing functionality was modified to include a minimum range parameter from which ray tracing starts to clear obstacles to avoid incorrectly clearing obstacles too close to the robot. This issue was mentioned in `ROS Answers <https://answers.ros.org/question/355150/obstacles-in-sensor-deadzone/>`_. An existing parameter `raytrace_range` was renamed to `raytrace_max_range` to reflect the functionality it affects. The renamed parameters and the plugins that they belong to are mentioned below. The changes were introduced in this `pull request <https://github.com/ros-planning/navigation2/pull/2126>`_.
+
+- obstacle_layer plugin
+ - ``raytrace_min_range`` controls the minimum range from which ray tracing clears obstacles from the costmap
+ - ``raytrace_max_range`` controls the maximum range to which ray tracing clears obstacles from the costmap
+- voxel_layer plugin
+ - ``raytrace_min_range`` controls the minimum range from which ray tracing clears obstacles from the costmap
+ - ``raytrace_max_range`` controls the maximum range to which ray tracing clears obstacles from the costmap

--- a/migration/Foxy.rst
+++ b/migration/Foxy.rst
@@ -110,7 +110,6 @@ To follow the SI units outlined in REP-103 to the "T" nodes below were modified 
 - map saver
  - ``save_map_timeout`` in seconds
 
-
 Ray Tracing Parameters
 **********************
 Raytracing functionality was modified to include a minimum range parameter from which ray tracing starts to clear obstacles to avoid incorrectly clearing obstacles too close to the robot. This issue was mentioned in `ROS Answers <https://answers.ros.org/question/355150/obstacles-in-sensor-deadzone/>`_. An existing parameter ``raytrace_range`` was renamed to ``raytrace_max_range`` to reflect the functionality it affects. The renamed parameters and the plugins that they belong to are mentioned below. The changes were introduced in this `pull request <https://github.com/ros-planning/navigation2/pull/2126>`_.
@@ -121,3 +120,14 @@ Raytracing functionality was modified to include a minimum range parameter from 
 - voxel_layer plugin
  - ``raytrace_min_range`` controls the minimum range from which ray tracing clears obstacles from the costmap
  - ``raytrace_max_range`` controls the maximum range to which ray tracing clears obstacles from the costmap
+
+Obstacle Marking Parameters
+***************************
+Obstacle marking was modified to include a minimum range parameter from which obstacles are marked on the costmap to prevent addition of obstacles in the costmap due to noisy and incorrect measurements. This modification is related to the change with the raytracing parameters. The renamed parameters, newly added parameters and the plugins they belong to are given below.
+
+- obstacle_layer plugin
+ - ``obstacle_min_range`` controls the minimum range from which obstacle are marked on the costmap
+ - ``obstacle_max_range`` controls the maximum range to which obstacles are marked on the costmap
+- voxel_layer plugin
+ - ``obstacle_min_range`` controls the minimum range from which obstacle are marked on the costmap
+ - ``obstacle_max_range`` controls the maximum range to which obstacles are marked on the costmap


### PR DESCRIPTION
## Description 

* Documenting the `raytrace_min_range` and `raytrace_max_range` params introduced in this [pull request](https://github.com/ros-planning/navigation2/pull/2126).
