### PR TITLE
Enable absolute values for speed_filter

### DIFF
--- a/configuration/packages/configuring-map-server.rst
+++ b/configuration/packages/configuring-map-server.rst
@@ -98,7 +98,7 @@ Costmap Filter Info Server Parameters
 
     - 0: keepout zones / preferred lanes filter
     - 1: speed filter, speed limit is specified in % of maximum speed
-    - 2: speed filter, speed limit is specified in absolute value (not implemented yet)
+    - 2: speed filter, speed limit is specified in absolute value (m/s)
 
 :filter_info_topic:
 

--- a/configuration/packages/costmap-plugins/speed_filter.rst
+++ b/configuration/packages/costmap-plugins/speed_filter.rst
@@ -50,9 +50,6 @@ Speed Filter - is a Costmap Filter that restricting maximum velocity of robot. T
 
     - ``percentage``: speed limit is expressed in percentage if ``true`` or in absolute values in ``false`` case. This parameter is set depending on ``type`` field of ``CostmapFilterInfo`` message.
 
-      Note
-        Speed limit in absolute values is not supported yet.
-
     - ``speed_limit``: non-zero values show maximum allowed speed expressed in a percent of maximum robot speed or in absolute value depending on ``percentage`` value. Zero value means no speed restriction (independently on ``percentage``). ``speed_limit`` is being linearly converted from ``OccupancyGrid`` filter mask value as: ``speed_limit = base + multiplier * mask_value``, where ``base`` and ``multiplier`` coefficients are taken from ``CostmapFilterInfo`` message.
 
       Note


### PR DESCRIPTION
This complements https://github.com/ros-planning/navigation2/pull/2149 work.