### PR TITLE
planner_selector in migration guide

### DIFF
--- a/configuration/packages/bt-plugins/actions/PlannerSelector.rst
+++ b/configuration/packages/bt-plugins/actions/PlannerSelector.rst
@@ -1,0 +1,56 @@
+.. _bt_planner_selector_node:
+
+PlannerSelector
+==============
+
+It is used to switch the planner that will be used by the planner server. It subscribes to the "planner_selector" topic to get name of the planner to be used. It is used before of the ComputePathToPoseAction. The selected_planner output port is passed to planner_id input port of the ComputePathToPoseAction.
+
+.. _bt_navigator: https://github.com/ros-planning/navigation2/tree/main/nav2_bt_navigator
+
+Input Ports
+-----------
+
+:topic_name:
+
+  ====== =======
+  Type   Default
+  ------ -------
+  string planner_selector  
+  ====== =======
+
+  Description
+    	The name of the topic used to received select command messages. This is used to support multiple PlannerSelector nodes. 
+      
+:default_planner:
+
+  ====== =======
+  Type   Default
+  ------ -------
+  string N/A  
+  ====== =======
+
+  Description
+    	The default value for the selected planner if no message is received from the input topic.
+
+
+Output Ports
+-----------
+
+:selected_planner:
+
+  ====== =======
+  Type   Default
+  ------ -------
+  string N/A  
+  ====== =======
+
+  Description
+    	The output selected planner id. This selected_planner string is usually passed to the ComputePathToPose behavior via the planner_id input port.
+
+
+Example
+-------
+
+.. code-block:: xml
+
+  <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased" topic_name="planner_selector"/>

--- a/configuration/packages/bt-plugins/actions/PlannerSelector.rst
+++ b/configuration/packages/bt-plugins/actions/PlannerSelector.rst
@@ -3,7 +3,7 @@
 PlannerSelector
 ==============
 
-It is used to select the planner that will be used by the planner server. It subscribes to the _planner_selector_ topic to recive command msgs with the name of the planner to be used. It is commonly used before of the ComputePathToPoseAction. The selected_planner output port is passed to planner_id input port of the ComputePathToPoseAction.
+It is used to select the planner that will be used by the planner server. It subscribes to the ``planner_selector`` topic to receive command messages with the name of the planner to be used. It is commonly used before of the ComputePathToPoseAction. The ``selected_planner`` output port is passed to ``planner_id`` input port of the ComputePathToPoseAction. If none is provided on the topic, the ``default_planner`` is used.
 
 .. _bt_navigator: https://github.com/ros-planning/navigation2/tree/main/nav2_bt_navigator
 

--- a/configuration/packages/bt-plugins/actions/PlannerSelector.rst
+++ b/configuration/packages/bt-plugins/actions/PlannerSelector.rst
@@ -3,7 +3,7 @@
 PlannerSelector
 ==============
 
-It is used to switch the planner that will be used by the planner server. It subscribes to the "planner_selector" topic to get name of the planner to be used. It is used before of the ComputePathToPoseAction. The selected_planner output port is passed to planner_id input port of the ComputePathToPoseAction.
+It is used to select the planner that will be used by the planner server. It subscribes to the _planner_selector_ topic to recive command msgs with the name of the planner to be used. It is commonly used before of the ComputePathToPoseAction. The selected_planner output port is passed to planner_id input port of the ComputePathToPoseAction.
 
 .. _bt_navigator: https://github.com/ros-planning/navigation2/tree/main/nav2_bt_navigator
 

--- a/configuration/packages/configuring-bt-xml.rst
+++ b/configuration/packages/configuring-bt-xml.rst
@@ -30,6 +30,7 @@ Action Plugins
   bt-plugins/actions/ClearCostmapAroundRobot.rst
   bt-plugins/actions/ReinitializeGlobalLocalization.rst
   bt-plugins/actions/TruncatePath.rst
+  bt-plugins/actions/PlannerSelector.rst
 
 Condition Plugins
 *****************

--- a/migration/Foxy.rst
+++ b/migration/Foxy.rst
@@ -199,3 +199,21 @@ These plugins are set as default in the ``nav2_bt_navigator`` but may be overrid
 Original GitHub tickets:
 
 - `SingleTrigger <https://github.com/ros-planning/navigation2/pull/2236>`_
+
+Planner Selector Behavior Tree Node
+***********************
+The PlannerSelector behavior is used to switch the planner that will be used by the planner server. It subscribes to a topic "planner_selector" to get the decision about what planner must be used. It is usually used before of the ComputePathToPoseAction. The selected_planner output port is passed to planner_id input port of the ComputePathToPoseAction.
+
+ - `Pull Request <https://github.com/ros-planning/navigation2/pull/2249>`
+ - `Discussion <https://github.com/ros-planning/navigation.ros.org/issues/147>`
+ 
+ *Example*
+ ```
+<root main_tree_to_execute = "MainTree" >
+    <BehaviorTree ID="MainTree">
+        <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased"/>
+        <ComputePathToPoseAction planner_id="{selected_planner}"/>
+    </BehaviorTree>
+</root>
+```
+ ```

--- a/migration/Foxy.rst
+++ b/migration/Foxy.rst
@@ -206,14 +206,3 @@ The PlannerSelector behavior is used to switch the planner that will be used by 
 
  - `Pull Request <https://github.com/ros-planning/navigation2/pull/2249>`
  - `Discussion <https://github.com/ros-planning/navigation.ros.org/issues/147>`
- 
- *Example*
- ```
-<root main_tree_to_execute = "MainTree" >
-    <BehaviorTree ID="MainTree">
-        <PlannerSelector selected_planner="{selected_planner}" default_planner="GridBased"/>
-        <ComputePathToPoseAction planner_id="{selected_planner}"/>
-    </BehaviorTree>
-</root>
-```
- ```

--- a/migration/Foxy.rst
+++ b/migration/Foxy.rst
@@ -199,10 +199,4 @@ These plugins are set as default in the ``nav2_bt_navigator`` but may be overrid
 Original GitHub tickets:
 
 - `SingleTrigger <https://github.com/ros-planning/navigation2/pull/2236>`_
-
-Planner Selector Behavior Tree Node
-***********************
-The PlannerSelector behavior is used to switch the planner that will be used by the planner server. It subscribes to a topic "planner_selector" to get the decision about what planner must be used. It is usually used before of the ComputePathToPoseAction. The selected_planner output port is passed to planner_id input port of the ComputePathToPoseAction.
-
- - `Pull Request <https://github.com/ros-planning/navigation2/pull/2249>`
- - `Discussion <https://github.com/ros-planning/navigation.ros.org/issues/147>`
+- `PlannerSelector <https://github.com/ros-planning/navigation2/pull/2249>`_

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -244,7 +244,9 @@ Behavior Tree Nodes
 +--------------------------------------------+---------------------+------------------------------------------+
 | `Truncate Path`_                           | Francisco Martín    | Modifies a path making it shorter        |
 +--------------------------------------------+---------------------+------------------------------------------+
-| `Planner Selector`_                        | Pablo Iñigo Blasco  | Selects the global planner               |
+| `Planner Selector`_                        | Pablo Iñigo Blasco  | Selects the global planner based on a    |
+|                                            |                     | topic input, otherwises uses a default   |
+|                                            |                     | planner id                               |
 +--------------------------------------------+---------------------+------------------------------------------+
 .. _Back Up Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/back_up_action.cpp
 .. _Clear Entire Costmap Service: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp

--- a/plugins/index.rst
+++ b/plugins/index.rst
@@ -244,7 +244,8 @@ Behavior Tree Nodes
 +--------------------------------------------+---------------------+------------------------------------------+
 | `Truncate Path`_                           | Francisco Martín    | Modifies a path making it shorter        |
 +--------------------------------------------+---------------------+------------------------------------------+
-
+| `Planner Selector`_                        | Pablo Iñigo Blasco  | Selects the global planner               |
++--------------------------------------------+---------------------+------------------------------------------+
 .. _Back Up Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/back_up_action.cpp
 .. _Clear Entire Costmap Service: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
 .. _Clear Costmap Except Region Service: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/clear_costmap_service.cpp
@@ -256,6 +257,8 @@ Behavior Tree Nodes
 .. _Spin Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/spin_action.cpp
 .. _Wait Action: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/wait_action.cpp
 .. _Truncate Path: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/truncate_path_action.cpp
+.. _Planner Selector: https://github.com/ros-planning/navigation2/tree/main/nav2_behavior_tree/plugins/action/planner_selector.cpp
+
 
 
 +------------------------------------+--------------------+------------------------+


### PR DESCRIPTION
Simple documentation to include the planner_selector on the migration guide.