### PR TITLE
Build Nav2 Dependencies is erro

### DIFF
--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -124,6 +124,7 @@ Then, use ``vcs`` to clone the repos and versions in it into a workspace.
   cd ~/nav2_depend_ws
   wget https://raw.githubusercontent.com/ros-planning/navigation2/main/tools/underlay.repos
   vcs import src < underlay.repos
+  vcs custom --args checkout foxy
   rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>
   colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION
http://gazebosim.org/tutorials?tut=ros2_installing&cat=connect_ros
https://github.com/ros/bond_core/issues/71

underlay.repos

repositories:
  BehaviorTree/BehaviorTree.CPP:
    type: git
    url: https://github.com/BehaviorTree/BehaviorTree.CPP.git
    version: master
  ros/angles:
    type: git
    url: https://github.com/ros/angles.git
    version: ros2
  ros-simulation/gazebo_ros_pkgs:
    type: git
    url: https://github.com/ros-simulation/gazebo_ros_pkgs.git
    version: ros2
  ros-perception/image_common:
    type: git
    url: https://github.com/ros-perception/image_common.git
    version: ros2
  ros-perception/vision_opencv:
    type: git
    url: https://github.com/ros-perception/vision_opencv.git
    version: ros2
  ros/bond_core:
    type: git
    url: https://github.com/ros/bond_core.git
    version: dashing-devel
  ompl/ompl:
    type: git
    url: https://github.com/ompl/ompl.git
    version: 1.5.0