### PR TITLE
Changing distros for pluginlib syntax change

### DIFF
--- a/plugin_tutorials/docs/writing_new_costmap2d_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_costmap2d_plugin.rst
@@ -195,12 +195,12 @@ For example:
          width: 3
          height: 3
          resolution: 0.05
-  -      plugin_names: ["obstacle_layer", "voxel_layer", "inflation_layer"] # For Foxy and earlier
-  -      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_costmap_2d::InflationLayer"] # For Foxy and earlier
-  +      plugin_names: ["obstacle_layer", "voxel_layer", "gradient_layer"] # For Foxy and earlier
-  +      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_gradient_costmap_plugin/GradientLayer"] # For Foxy and earlier
-  -      plugins: ["obstacle_layer", "voxel_layer", "inflation_layer"] # For Galactic and later
-  +      plugins: ["obstacle_layer", "voxel_layer", "gradient_layer"] # For Galactic and later
+  -      plugin_names: ["obstacle_layer", "voxel_layer", "inflation_layer"] # For Eloquent and earlier
+  -      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_costmap_2d::InflationLayer"] # For Eloquent and earlier
+  +      plugin_names: ["obstacle_layer", "voxel_layer", "gradient_layer"] # For Eloquent and earlier
+  +      plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_gradient_costmap_plugin/GradientLayer"] # For Eloquent and earlier
+  -      plugins: ["obstacle_layer", "voxel_layer", "inflation_layer"] # For Foxy and later
+  +      plugins: ["obstacle_layer", "voxel_layer", "gradient_layer"] # For Foxy and later
          robot_radius: 0.22
          inflation_layer:
            cost_scaling_factor: 3.0
@@ -208,12 +208,12 @@ For example:
          robot_base_frame: base_link
          global_frame: map
          use_sim_time: True
-  -      plugin_names: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"] # For Foxy and earlier
-  -      plugin_types: ["nav2_costmap_2d::StaticLayer", "nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_costmap_2d::InflationLayer"] # For Foxy and earlier
-  +      plugin_names: ["static_layer", "obstacle_layer", "voxel_layer", "gradient_layer"] # For Foxy and earlier
-  +      plugin_types: ["nav2_costmap_2d::StaticLayer", "nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_gradient_costmap_plugin/GradientLayer"] # For Foxy and earlier
-  -      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"] # For Galactic and later
-  +      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "gradient_layer"] # For Galactic and later
+  -      plugin_names: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"] # For Eloquent and earlier
+  -      plugin_types: ["nav2_costmap_2d::StaticLayer", "nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_costmap_2d::InflationLayer"] # For Eloquent and earlier
+  +      plugin_names: ["static_layer", "obstacle_layer", "voxel_layer", "gradient_layer"] # For Eloquent and earlier
+  +      plugin_types: ["nav2_costmap_2d::StaticLayer", "nav2_costmap_2d::ObstacleLayer", "nav2_costmap_2d::VoxelLayer", "nav2_gradient_costmap_plugin/GradientLayer"] # For Eloquent and earlier
+  -      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "inflation_layer"] # For Foxy and later
+  +      plugins: ["static_layer", "obstacle_layer", "voxel_layer", "gradient_layer"] # For Foxy and later
          robot_radius: 0.22
          resolution: 0.05
          obstacle_layer:
@@ -224,20 +224,20 @@ NOTE: there could be many simultaneously loaded plugin objects of one type. For 
 
 .. code-block:: text
 
-  plugin_names: ["obstacle_layer", "gradient_layer_1", "gradient_layer_2"] # For Foxy and earlier
-  plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_gradient_costmap_plugin/GradientLayer", "nav2_gradient_costmap_plugin/GradientLayer"] # For Foxy and earlier
-  plugins: ["obstacle_layer", "gradient_layer_1", "gradient_layer_2"] # For Galactic and later
+  plugin_names: ["obstacle_layer", "gradient_layer_1", "gradient_layer_2"] # For Eloquent and earlier
+  plugin_types: ["nav2_costmap_2d::ObstacleLayer", "nav2_gradient_costmap_plugin/GradientLayer", "nav2_gradient_costmap_plugin/GradientLayer"] # For Eloquent and earlier
+  plugins: ["obstacle_layer", "gradient_layer_1", "gradient_layer_2"] # For Foxy and later
 
 In this case each plugin object will be handled by its own parameters tree in a YAML-file, like:
 
 .. code-block:: text
 
   gradient_layer_1:
-    plugin: nav2_gradient_costmap_plugin/GradientLayer # For Galactic and later
+    plugin: nav2_gradient_costmap_plugin/GradientLayer # For Foxy and later
     enabled: True
     ...
   gradient_layer_2:
-    plugin: nav2_gradient_costmap_plugin/GradientLayer # For Galactic and later
+    plugin: nav2_gradient_costmap_plugin/GradientLayer # For Foxy and later
     enabled: False
     ...
 

--- a/plugin_tutorials/docs/writing_new_nav2planner_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_nav2planner_plugin.rst
@@ -197,12 +197,12 @@ To enable the plugin, we need to modify the ``nav2_params.yaml`` file as belowto
 
   planner_server:
   ros__parameters:
-    planner_plugin_types: ["nav2_navfn_planner/NavfnPlanner"] # For Foxy and earlier
-    planner_plugin_ids: ["GridBased"] # For Foxy and earlier
-    plugins: ["GridBased"] # For Galactic and later
+    planner_plugin_types: ["nav2_navfn_planner/NavfnPlanner"] # For Eloquent and earlier
+    planner_plugin_ids: ["GridBased"] # For Eloquent and earlier
+    plugins: ["GridBased"] # For Foxy and later
     use_sim_time: True
     GridBased:
-      plugin: nav2_navfn_planner/NavfnPlanner # For Galactic and later
+      plugin: nav2_navfn_planner/NavfnPlanner # For Foxy and later
       tolerance: 2.0
       use_astar: false
       allow_unknown: true
@@ -213,12 +213,12 @@ with
 
   planner_server:
   ros__parameters:
-    planner_plugin_types: ["nav2_straightline_planner/StraightLine"] # For Foxy and earlier
-    planner_plugin_ids: ["GridBased"] # For Foxy and earlier
-    plugins: ["GridBased"] # For Galactic and later
+    planner_plugin_types: ["nav2_straightline_planner/StraightLine"] # For Eloquent and earlier
+    planner_plugin_ids: ["GridBased"] # For Eloquent and earlier
+    plugins: ["GridBased"] # For Foxy and later
     use_sim_time: True
     GridBased:
-      plugin: nav2_straightline_planner/StraightLine # For Galactic and later
+      plugin: nav2_straightline_planner/StraightLine # For Foxy and later
       interpolation_resolution: 0.1
 
 In the above snippet, you can observe the mapping of our ``nav2_straightline_planner/StraightLine`` planner to its id ``GridBased``. To pass plugin-specific parameters we have used ``<plugin_id>.<plugin_specific_parameter>``.

--- a/tutorials/docs/navigation2_with_stvl.rst
+++ b/tutorials/docs/navigation2_with_stvl.rst
@@ -77,9 +77,9 @@ For example, the following will load the static and obstacle layer plugins into 
       global_costmap:
         ros__parameters:
           use_sim_time: True
-          plugin_names: ["static_layer", "obstacle_layer"] # For Foxy and earlier
-          plugins: ["static_layer", "obstacle_layer"] # For Galactic and later
-          plugin_types: ["nav2_costmap_2d::StaticLayer", "nav2_costmap_2d::ObstacleLayer"] # For Foxy and earlier
+          plugin_names: ["static_layer", "obstacle_layer"] # For Eloquent and earlier
+          plugins: ["static_layer", "obstacle_layer"] # For Foxy and later
+          plugin_types: ["nav2_costmap_2d::StaticLayer", "nav2_costmap_2d::ObstacleLayer"] # For Eloquent and earlier
 
 .. note::
 
@@ -94,9 +94,9 @@ For example, if the application required an STVL layer and no obstacle layer, ou
       global_costmap:
         ros__parameters:
           use_sim_time: True
-          plugin_names: ["static_layer", "stvl_layer"] # For Foxy and earlier
-          plugins: ["static_layer", "stvl_layer"] # For Galactic and later
-          plugin_types: ["nav2_costmap_2d::StaticLayer", "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer"] # For Foxy and earlier
+          plugin_names: ["static_layer", "stvl_layer"] # For Eloquent and earlier
+          plugins: ["static_layer", "stvl_layer"] # For Foxy and later
+          plugin_types: ["nav2_costmap_2d::StaticLayer", "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer"] # For Eloquent and earlier
 
 Similar to the Voxel Layer, after registering the plugin, we can add the configuration of the STVL layer under the namespace ``stvl_layer``.
 An example fully-described parameterization of an STVL configuration is:
@@ -104,7 +104,7 @@ An example fully-described parameterization of an STVL configuration is:
 .. code-block:: yaml
 
     stvl_layer:
-      plugin: "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer" # For Galactic and later
+      plugin: "spatio_temporal_voxel_layer/SpatioTemporalVoxelLayer" # For Foxy and later
       enabled: true
       voxel_decay: 15.
       decay_model: 0


### PR DESCRIPTION
Plugin server updates happened between `Eloquent` and `Foxy`, not between `Foxy` and `Galactic` as originally  written. 

For quick check of correctness: `foxy-devel` branch of Nav2 uses `plugin` and not `plugin_name`/`plugin_type`, https://github.com/ros-planning/navigation2/blob/2e18dd1cae31807f68746eb1a2c702526a34f4cc/nav2_bringup/bringup/params/nav2_params.yaml#L170

See full thread here: https://navigation2.slack.com/archives/C012L20NQLV/p1622570382026000