### PR TITLE
updating docker build instructions and guidance

### DIFF
--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -147,12 +147,7 @@ The rest of this should look familiar.
 Docker
 ******
 
-.. note::
-
-  To avoid using `sudo` to use docker, add your use to the `docker` group as outlined here for a Linux host machine: https://docs.docker.com/engine/install/linux-postinstall/
-  If you choose not to do this, you must run the below docker commands as `sudo`
-
-The official Dockerhub entries are primarily for use in the Nav2 CI, but they may also be used for development use to get a docker image that tracks Nav2 ``main`` branch. The ``Dockerfile`` in the root of the repository is recommended for production use, set to your distribution of choice. 
+The official Dockerhub entries are primarily for use in the Nav2 CI, but they may also be used for development use to get a docker image that tracks Nav2 ``main`` branch. The ``Dockerfile`` in the root of the repository is recommended for production use, set to your distribution of choice.
 
 It is though generally recomended to install Nav2 releases from the apt repository inside a container if you'd like to use our released binaries.
 
@@ -167,13 +162,13 @@ First, clone the repo to your local system (or see Building the source above)
 
 .. code:: bash
 
-  docker build -t nav2/latest .
+  sudo docker build -t nav2/latest .
 
 If proxies are needed:
 
 .. code:: bash
 
-  docker build -t nav2/latest --build-arg http_proxy=http://proxy.my.com:### --build-arg https_proxy=http://proxy.my.com:### .
+  sudo docker build -t nav2/latest --build-arg http_proxy=http://proxy.my.com:### --build-arg https_proxy=http://proxy.my.com:### .
 
 Note: You may also need to configure your docker for DNS to work. See article here for details: https://development.robinwinslow.uk/2016/06/23/fix-docker-networking-dns/
 
@@ -181,8 +176,8 @@ If you would like to build from dockerhub cache to speed up the build
 
 .. code:: bash
 
-  docker pull rosplanning/navigation2:main
-  docker build -t nav2/latest --cache-from rosplanning/navigation2:main .
+  sudo docker pull rosplanning/navigation2:main
+  sudo docker build -t nav2/latest --cache-from rosplanning/navigation2:main .
 
 
 .. rst-class:: content-collapse

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -187,6 +187,7 @@ We allow for you to pull the latest docker image from the main branch at any tim
 This docker image will not contain a built overlay, and you must build the overlay Nav2 workspace yourself (see Build Nav2 Main up above).
 
 .. code:: bash
+
   sudo docker pull rosplanning/navigation2:main
 
 !!!!

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -147,7 +147,7 @@ The rest of this should look familiar.
 Docker
 ******
 
-The official Dockerhub entries are primarily for use in the Nav2 CI, but they may also be used for development use to get a docker image that tracks Nav2 ``main`` branch. The ``Dockerfile`` in the root of the repository is recommended for production use, set to your distribution of choice.
+The official Dockerhub entries are primarily for use in the Nav2 CI, but they may also be used for development. It is useful to have a docker image that tracks Nav2 ``main`` branch. The ``Dockerfile`` in the root of the repository is recommended for production use, set to your distribution of choice.
 
 It is though generally recomended to install Nav2 releases from the apt repository inside a container if you'd like to use our released binaries.
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -148,8 +148,8 @@ Docker
 ******
 
 
-There are 2 options for docker with Nav2:
-building a container and using the DockerHub container.
+Docker is primarily used for the Nav2 CI.
+For Nav2 production use inside a container, it is typically better to install Nav2 releases from the apt repository inside a ROS container.
 
 .. rst-class:: content-collapse
 
@@ -158,6 +158,7 @@ Building Docker Container
 
 To build an image from the Dockerfile in the Nav2 folder:
 First, clone the repo to your local system (or see Building the source above)
+You may cache from the Dockerhub container.
 
 .. code:: bash
 
@@ -171,16 +172,15 @@ If proxies are needed:
 
 Note: You may also need to configure your docker for DNS to work. See article here for details: https://development.robinwinslow.uk/2016/06/23/fix-docker-networking-dns/
 
-.. rst-class:: content-collapse
-
-Using DockerHub Container
-=========================
-
-We allow for you to pull the latest docker image from the main branch at any time. As new releases and tags are made, docker containers on docker hub will be versioned as well to chose from.
+If you would like to build from dockerhub cache
 
 .. code:: bash
 
-  sudo docker pull rosplanning/navigation2:main.release
+  sudo docker pull rosplanning/navigation2:main
+  sudo docker build -t nav2/latest --cache-from rosplanning/navigation2:main .
+
+
+.. rst-class:: content-collapse
 
 !!!!
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -184,7 +184,8 @@ If you would like to build from dockerhub cache to speed up the build
 Using DockerHub Container
 =========================
 We allow for you to pull the latest docker image from the main branch at any time. As new releases and tags are made, docker containers on docker hub will be versioned as well to chose from.
-This docker image will not contain a built overlay, and you must build the overlay Nav2 workspace yourself (see Build Nav2 Main up above)
+This docker image will not contain a built overlay, and you must build the overlay Nav2 workspace yourself (see Build Nav2 Main up above).
+
 .. code:: bash
   sudo docker pull rosplanning/navigation2:main
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -177,7 +177,7 @@ If proxies are needed:
 
 Note: You may also need to configure your docker for DNS to work. See article here for details: https://development.robinwinslow.uk/2016/06/23/fix-docker-networking-dns/
 
-If you would like to build from dockerhub cache to seped up the build
+If you would like to build from dockerhub cache to speed up the build
 
 .. code:: bash
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -152,9 +152,9 @@ Docker
   To avoid using `sudo` to use docker, add your use to the `docker` group as outlined here for a Linux host machine: https://docs.docker.com/engine/install/linux-postinstall/
   If you choose not to do this, you must run the below docker commands as `sudo`
 
-The official Dockerfile and Dockerhub container are primarily for use in the Nav2 CI
+The official Dockerhub entries are primarily for use in the Nav2 CI, but they may also be used for development use to get a docker image that tracks Nav2 ``main`` branch. The ``Dockerfile`` in the root of the repository is recommended for production use, set to your distribution of choice. 
 
-For Nav2 production containerized use, it is reccomended to install Nav2 releases from the apt repository inside a ROS container
+It is though generally recomended to install Nav2 releases from the apt repository inside a container if you'd like to use our released binaries.
 
 .. rst-class:: content-collapse
 

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -147,9 +147,14 @@ The rest of this should look familiar.
 Docker
 ******
 
+.. note::
 
-Docker is primarily used for the Nav2 CI.
-For Nav2 production use inside a container, it is typically better to install Nav2 releases from the apt repository inside a ROS container.
+  To avoid using `sudo` to use docker, add your use to the `docker` group as outlined here for a Linux host machine: https://docs.docker.com/engine/install/linux-postinstall/
+  If you choose not to do this, you must run the below docker commands as `sudo`
+
+The official Dockerfile and Dockerhub container are primarily for use in the Nav2 CI
+
+For Nav2 production containerized use, it is reccomended to install Nav2 releases from the apt repository inside a ROS container
 
 .. rst-class:: content-collapse
 
@@ -158,26 +163,26 @@ Building Docker Container
 
 To build an image from the Dockerfile in the Nav2 folder:
 First, clone the repo to your local system (or see Building the source above)
-You may cache from the Dockerhub container.
+
 
 .. code:: bash
 
-  sudo docker build -t nav2/latest .
+  docker build -t nav2/latest .
 
 If proxies are needed:
 
 .. code:: bash
 
-  sudo docker build -t nav2/latest --build-arg http_proxy=http://proxy.my.com:### --build-arg https_proxy=http://proxy.my.com:### .
+  docker build -t nav2/latest --build-arg http_proxy=http://proxy.my.com:### --build-arg https_proxy=http://proxy.my.com:### .
 
 Note: You may also need to configure your docker for DNS to work. See article here for details: https://development.robinwinslow.uk/2016/06/23/fix-docker-networking-dns/
 
-If you would like to build from dockerhub cache
+If you would like to build from dockerhub cache to seped up the build
 
 .. code:: bash
 
-  sudo docker pull rosplanning/navigation2:main
-  sudo docker build -t nav2/latest --cache-from rosplanning/navigation2:main .
+  docker pull rosplanning/navigation2:main
+  docker build -t nav2/latest --cache-from rosplanning/navigation2:main .
 
 
 .. rst-class:: content-collapse

--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -179,8 +179,14 @@ If you would like to build from dockerhub cache to speed up the build
   sudo docker pull rosplanning/navigation2:main
   sudo docker build -t nav2/latest --cache-from rosplanning/navigation2:main .
 
-
 .. rst-class:: content-collapse
+
+Using DockerHub Container
+=========================
+We allow for you to pull the latest docker image from the main branch at any time. As new releases and tags are made, docker containers on docker hub will be versioned as well to chose from.
+This docker image will not contain a built overlay, and you must build the overlay Nav2 workspace yourself (see Build Nav2 Main up above)
+.. code:: bash
+  sudo docker pull rosplanning/navigation2:main
 
 !!!!
 


### PR DESCRIPTION
As per https://github.com/ros-planning/navigation2/issues/2388 Docker instructions on the documentation need to change. 
It is now recommended to install from apt, unless for development purposes. 