### PR TITLE
Update links to ROS 2 docs

### DIFF
--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -30,7 +30,7 @@ Build Nav2 For Released Distribution
 Install ROS
 -----------
 
-Please install ROS 2 via the usual `build instructions <https://index.ros.org/doc/ros2/Installation>`_ for your desired distribution.
+Please install ROS 2 via the usual `build instructions <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Binary.html>`_ for your desired distribution.
 
 Build Nav2
 ----------
@@ -59,7 +59,7 @@ Quickstart Build Main
 Steps
 -----
 
-Install all ROS 2 dependencies from the `ROS 2 Installation page <https://index.ros.org/doc/ros2/Installation/>`_.
+Install all ROS 2 dependencies from the `ROS 2 Installation page <https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html#system-setup>`_.
 Ensure there are no ROS environment variables set in your terminal or `.bashrc` file before taking the steps below.*
 
 
@@ -103,7 +103,7 @@ Build ROS 2 Main
 
    When building ROS 2 from source, make sure that the `ros2.repos` file is from the `main` branch.
 
-Build ROS 2 main using the `build instructions <https://index.ros.org/doc/ros2/Installation>`_ provided in the ROS 2 documentation.
+Build ROS 2 main using the `build instructions <https://docs.ros.org/en/rolling/Installation/Ubuntu-Development-Setup.html>`_ provided in the ROS 2 documentation.
 
 
 Build Nav2 Dependencies

--- a/concepts/index.rst
+++ b/concepts/index.rst
@@ -8,7 +8,7 @@ This page is to help familiarize new robotists to the concepts of mobile robot n
 ROS 2
 *****
 
-ROS 2 is the core middleware used for Nav2. If you are unfamilar with this, please visit `the ROS 2 documentation <https://index.ros.org/doc/ros2/>`_ before continuing.
+ROS 2 is the core middleware used for Nav2. If you are unfamilar with this, please visit `the ROS 2 documentation <https://docs.ros.org/en/rolling/>`_ before continuing.
 
 Action Server
 =============
@@ -16,7 +16,7 @@ Action Server
 Just as in ROS, action servers are a common way to control long running tasks like navigation.
 This stack makes more extensive use of actions, and in some cases, without an easy topic interface.
 It is more important to understand action servers as a developer in ROS 2.
-Some simple CLI examples can be found in the `ROS 2 documementation <https://index.ros.org/doc/ros2/Tutorials/Understanding-ROS2-Actions/>`_.
+Some simple CLI examples can be found in the `ROS 2 documementation <https://docs.ros.org/en/rolling/Tutorials/Understanding-ROS2-Actions.html>`_.
 
 Action servers are similar to a canonical service server.
 A client will request some task to be completed, except, this task may take a long time.

--- a/setup_guides/transformation/setup_transforms.rst
+++ b/setup_guides/transformation/setup_transforms.rst
@@ -45,7 +45,7 @@ With this transform tree set up, converting the laser scan received in the ``bas
 Static Transform Publisher Demo
 *******************************
 
-.. warning:: If you are new to ROS2 or do not have a working environment yet, then please take some time to properly setup your machine using the resources in the official `ROS2 Installation Documentation <https://index.ros.org/doc/ros2/Installation/>`__
+.. warning:: If you are new to ROS 2 or do not have a working environment yet, then please take some time to properly setup your machine using the resources in the official `ROS 2 Installation Documentation <https://docs.ros.org/en/rolling/Installation.html>`__
 
 Now let's try publishing a very simple transform using the static_transform_publisher tool provided by TF2. We will be publishing a transformation from the link ``base_link`` to the link ``base_laser`` with a translation of (x: 0.1m, y: 0.0m, z: 0.2m). Note that we will be building the transform from the diagram earlier in this tutorial.
 

--- a/setup_guides/urdf/setup_urdf.rst
+++ b/setup_guides/urdf/setup_urdf.rst
@@ -249,7 +249,7 @@ Next, let us create our launch file. Launch files are used by ROS2 to bring up t
           rviz_node
       ])
 
-.. seealso:: For more information regarding the launch system in ROS2, you can have a look at the official `ROS2 Launch System Documentation <https://index.ros.org/doc/ros2/Tutorials/Launch-system/>`__
+.. seealso:: For more information regarding the launch system in ROS 2, you can have a look at the official `ROS 2 Launch System Documentation <https://docs.ros.org/en/rolling/Tutorials/Launch-system.html>`__
 
 To keep things simpler when we get to visualization, we have provided an RVIz config file that will be loaded when we launch our package. This configuration file initializes RVIz with the proper settings so you can view the robot immediately once it launches. Create a directory named ``rviz`` in the root of your project and a file named ``urdf_config.rviz`` under it. Place the following as the contents of ``urdf_config.rviz``
 

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -19,7 +19,7 @@
 
 .. |PP| replace:: https://github.com/ros-planning/navigation2/blob/main
 
-.. _`ROS 2 binary packages`: https://index.ros.org/doc/ros2/Installation/
+.. _`ROS 2 binary packages`: https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Binary.html
 
 .. _`official Turtlebot 3 manual`: http://emanual.robotis.com/docs/en/platform/turtlebot3/ros2_setup/
 

--- a/tutorials/docs/get_backtrace.rst
+++ b/tutorials/docs/get_backtrace.rst
@@ -199,7 +199,7 @@ Alternatively, if you server of interest is being launched in these files direct
 - Launch the server's node in another terminal following the instructions in `From a Node`_.
 
 .. note::
-  Note that in this case, you may need to remap or provide parameter files to this node if it was previously provided by the launch file. Using ``--ros-args`` you can give it the path to the new parameters file, remaps, or names. See `this ROS2 tutorial <https://index.ros.org/doc/ros2/Tutorials/Node-arguments/>`_ for the commandline arguments required.
+  Note that in this case, you may need to remap or provide parameter files to this node if it was previously provided by the launch file. Using ``--ros-args`` you can give it the path to the new parameters file, remaps, or names. See `this ROS2 tutorial <https://docs.ros.org/en/rolling/Guides/Node-arguments.html>`_ for the commandline arguments required.
 
   We understand this can be a pain, so it might encourage you to rather have each node possible as a separately included launch file to make debugging easier. An example set of arguments might be ``--ros-args -r __node:=<node_name> --params-file /absolute/path/to/params.yaml`` (as a template).
 


### PR DESCRIPTION
docs.ros.org has replaced index.ros.org/doc/ros2

I used `/rolling/` for the links because then they won't need to be updated.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>