### PR TITLE
Remove an extra parameter description in PreferForwardCritic page.

### DIFF
--- a/configuration/packages/trajectory_critics/prefer_forward.rst
+++ b/configuration/packages/trajectory_critics/prefer_forward.rst
@@ -67,14 +67,3 @@ Parameters
     
     Description
         Weighed scale for critic.
-
-:``<dwb plugin>``.\ ``<name>``.scale:
-
-  ====== =======
-  Type   Default
-  ------ -------
-  double 1.0 
-  ====== =======
-    
-    Description
-        Weighed scale for critic.


### PR DESCRIPTION
There are 2 "scale" descriptions in this page, and it seems like an extra content.