### PR TITLE
Updated setup_sensors.rst file with a Note 

### DIFF
--- a/setup_guides/sensors/setup_sensors.rst
+++ b/setup_guides/sensors/setup_sensors.rst
@@ -480,6 +480,7 @@ We can also check that the transforms are correct by executing the following lin
 
   ros2 run tf2_tools view_frames.py
 
+Note: For Galactic and newer, it should be ``view_frames`` and not ``view_frames.py``
 The line above will create a ``frames.pdf`` file that shows the current transform tree. Your tranform tree should be similar to the one shown below:
 
 .. image:: images/view_frames.png


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/66986430/157015168-ad086e0f-2ee1-4f28-9281-4c9f28c78ce3.png)
An error occurs while trying to execute the above line in Galactic version of ROS2

![image](https://user-images.githubusercontent.com/66986430/157015005-26a8fd36-9329-4425-97f4-e42545ef649d.png)

The following PR adds a note for changes required in the code while working with Galactic or newer version of ROS2. The reference can be seen in Tf2 tutorial (https://docs.ros.org/en/galactic/Tutorials/Tf2/Introduction-To-Tf2.html#tf2-tools) mentioned in ROS2 Galactic documentation. 
