### PR TITLE
Updated the ros__parameters of the Theta star planner in config guide

### DIFF
--- a/configuration/packages/configuring-thetastar.rst
+++ b/configuration/packages/configuring-thetastar.rst
@@ -83,9 +83,9 @@ Example
   ros__parameters:
     expected_planner_frequency: 20.0
     use_sim_time: True
-    planner_plugin_ids: ["GridBased"]
+    planner_plugins: ["GridBased"]
     GridBased:
-      plugin_types: "nav2_theta_star_planner/ThetaStarPlanner"
+      plugin: "nav2_theta_star_planner/ThetaStarPlanner"
       how_many_corners: 8
       w_euc_cost: 1.0
       w_traversal_cost: 2.0


### PR DESCRIPTION
The PR commit is in sync with the latest version of the ROS2. If ran with the unedited version of Theta Star Planner on Galactic Version of ROS2, it fails to recognize the parameters during the configuration stage of the planner and defaults to NavFn_Planner.