### PR TITLE
Add docs for basic_navigator.destroyNode()

### DIFF
--- a/commander_api/index.rst
+++ b/commander_api/index.rst
@@ -119,6 +119,8 @@ If a server fails, it may throw an exception or return a `None` object, so pleas
 +---------------------------------------+----------------------------------------------------------------------------+
 | lifecycleShutdown()                   | Sends a request to all lifecycle management servers to shut them down.     |
 +---------------------------------------+----------------------------------------------------------------------------+
+| destroyNode()                         | Releases the resources used by the object.                                 |
++---------------------------------------+----------------------------------------------------------------------------+
 
 Examples and Demos
 ******************


### PR DESCRIPTION
Documentation for `destroyNode()` function proposed here: https://github.com/ros-planning/navigation2/pull/2924