### PR TITLE
fixed typo

### DIFF
--- a/configuration/packages/configuring-amcl.rst
+++ b/configuration/packages/configuring-amcl.rst
@@ -144,7 +144,7 @@ Parameters
   Description
     Exponential decay parameter for z_short part of model.
 
-:laser_likihood_max_dist:
+:laser_likelihood_max_dist:
 
   ============== =============================
   Type           Default                                               


### PR DESCRIPTION
this typo can lead to copy paste errors when setting up ones param file