### PR TITLE
upgrading breathe version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,7 @@ references:
         apt install openjdk-8-jre -y
         apt install bash git openssh-server -y
         apt install python3-pip python3 -y
-        apt install python3-sphinx -y
-        pip3 install docutils==0.14 sphinx_rtd_theme breathe==4.28.0 sphinxcontrib-plantuml jinja2==3.0.3
+        pip3 install sphinx==3.5.0 docutils==0.14 sphinx_rtd_theme breathe==4.28.0 sphinxcontrib-plantuml jinja2==3.0.3
   make_docs: &make_docs
     run:
       command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,8 @@ references:
         apt install openjdk-8-jre -y
         apt install bash git openssh-server -y
         apt install python3-pip python3 -y
-        pip3 install sphinx==1.7.5 docutils==0.14 sphinx_rtd_theme breathe==4.9.1 sphinxcontrib-plantuml jinja2==3.0.3
+        apt install python3-sphinx -y
+        pip3 install docutils==0.14 sphinx_rtd_theme breathe==4.28.0 sphinxcontrib-plantuml jinja2==3.0.3
   make_docs: &make_docs
     run:
       command: |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This folder holds the source and configuration files used to generate the
 Dependencies for Build: 
 * [Sphinx](https://www.sphinx-doc.org/en/master/usage/installation.html)
 * `sudo apt install python3-pip`
-* `pip3 install breathe==4.9.1 sphinx_rtd_theme sphinxcontrib-plantuml jinja2==3.0.3`
+* `pip3 install breathe==4.28.0 sphinx_rtd_theme sphinxcontrib-plantuml jinja2==3.0.3`
 
 Build the docs locally with `make html` and you'll find the built docs entry point in `_build/html/index.html`.
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ This folder holds the source and configuration files used to generate the
 [Navigation2 documentation](https://navigation.ros.org) web site.
 
 Dependencies for Build: 
-* [Sphinx](https://www.sphinx-doc.org/en/master/usage/installation.html)
 * `sudo apt install python3-pip`
-* `pip3 install breathe==4.28.0 sphinx_rtd_theme sphinxcontrib-plantuml jinja2==3.0.3`
+* `pip3 install sphinx==3.5.0 breathe==4.28.0 sphinx_rtd_theme sphinxcontrib-plantuml jinja2==3.0.3`
 
 Build the docs locally with `make html` and you'll find the built docs entry point in `_build/html/index.html`.
 


### PR DESCRIPTION
works on 20.04 and 22.04 as well.. #319 

apt-get installation of sphinx installs sphinx 1.8.0.. 

The newer version of Breathe supports versions between 3.0.0 and 3.5.0. Therefore, adding a pip3 install targeting the supported versioning for sphinx. 