### PR TITLE
Theta Star config lost one parma

### DIFF
--- a/configuration/packages/configuring-thetastar.rst
+++ b/configuration/packages/configuring-thetastar.rst
@@ -89,3 +89,4 @@ Example
       how_many_corners: 8
       w_euc_cost: 1.0
       w_traversal_cost: 2.0
+      w_heuristic_cost: 1.0


### PR DESCRIPTION
In order to run theta star planner,the official guide lost one parma:
w_heuristic_cost: 1.0