### PR TITLE
Add non headless start to example command

### DIFF
--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -50,7 +50,7 @@ Running the Example
 
    .. code-block:: bash
 
-      ros2 launch nav2_bringup tb3_simulation_launch.py
+      ros2 launch nav2_bringup tb3_simulation_launch.py headless:=False
    
    .. note::
 
@@ -59,6 +59,8 @@ Running the Example
       However, it is recommended to use the most recent `ROS 2 LTS distribution
       <https://ros.org/reps/rep-2000.html>`_  for improved stablity and feature
       completeness.
+      
+      headless defaults to true, if not set to false, gzclient (the 3d view) is not started
 
    This launch file will launch Nav2 with the AMCL localizer in the
    ``turtlebot3_world`` world.


### PR DESCRIPTION
[Fixes #3024](https://github.com/ros-planning/navigation2/issues/3024)