### PR TITLE
Update link to description on how to install ROS 2

### DIFF
--- a/substitutions.txt
+++ b/substitutions.txt
@@ -19,7 +19,7 @@
 
 .. |PP| replace:: https://github.com/ros-planning/navigation2/blob/main
 
-.. _`ROS 2 binary packages`: https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Binary.html
+.. _`ROS 2 binary packages`: https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html
 
 .. _`official Turtlebot 3 manual`: https://emanual.robotis.com/docs/en/platform/turtlebot3/quick-start/
 

--- a/substitutions.txt
+++ b/substitutions.txt
@@ -19,7 +19,7 @@
 
 .. |PP| replace:: https://github.com/ros-planning/navigation2/blob/main
 
-.. _`ROS 2 binary packages`: https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Install-Binary.html
+.. _`ROS 2 binary packages`: https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html
 
 .. _`official Turtlebot 3 manual`: https://emanual.robotis.com/docs/en/platform/turtlebot3/quick-start/
 


### PR DESCRIPTION
The page describing how to install ROS 2 was moved.