### PR TITLE
Fix checker width from 200mm to 20mm

### DIFF
--- a/tutorials/docs/camera_calibration.rst
+++ b/tutorials/docs/camera_calibration.rst
@@ -33,7 +33,7 @@ Requirements
 **Also, make sure you have the following:**
 
  • A large checkerboard with known dimensions. This tutorial uses a 7x9 checkerboard with 20mm squares. **Calibration uses the interior vertex points of the checkerboard, so an "8x10" board uses the interior vertex parameter "7x9" as in the example below.** The checkerboard with set dimensions can be downloaded from `here <https://calib.io/pages/camera-calibration-pattern-generator>`_.
- • A well lit 5m x 5m area clear of obstructions and check board patterns
+ • A well-lit area clear of obstructions and other check board patterns
 
  • A monocular camera publishing images over ROS
 

--- a/tutorials/docs/camera_calibration.rst
+++ b/tutorials/docs/camera_calibration.rst
@@ -32,7 +32,7 @@ Requirements
 
 **Also, make sure you have the following:**
 
- • A large checkerboard with known dimensions. This tutorial uses a 7x9 checkerboard with 200mm squares. **Calibration uses the interior vertex points of the checkerboard, so an "8x10" board uses the interior vertex parameter "7x9" as in the example below.** The checkerboard with set dimensions can be downloaded from `here <https://calib.io/pages/camera-calibration-pattern-generator>`_.
+ • A large checkerboard with known dimensions. This tutorial uses a 7x9 checkerboard with 20mm squares. **Calibration uses the interior vertex points of the checkerboard, so an "8x10" board uses the interior vertex parameter "7x9" as in the example below.** The checkerboard with set dimensions can be downloaded from `here <https://calib.io/pages/camera-calibration-pattern-generator>`_.
  • A well lit 5m x 5m area clear of obstructions and check board patterns
 
  • A monocular camera publishing images over ROS


### PR DESCRIPTION
Hmm, i see that the checkerboard was 200mm squares in the [original tutorial](http://wiki.ros.org/camera_calibration/Tutorials/MonocularCalibration)

 I'm going to convert this PR to a draft for now..