### PR TITLE
Add note for delayed startups

### DIFF
--- a/setup_guides/sensors/setup_sensors.rst
+++ b/setup_guides/sensors/setup_sensors.rst
@@ -505,11 +505,12 @@ Note that the parameters of the ``nav2_costmap_2d`` that we discussed in the pre
 
 After we have properly set up and launched Nav2, the ``/global_costmap`` and ``/local_costmap`` topics should now be active.
 
-Note: To make the costmaps show up, the 3 commands must be run in the right order
+.. note::  
+  To make the costmaps show up, run the 3 commands in this order
 
-#. Launching Description Nodes, RViz and Gazebo - in logs wait for "Connected to gazebo master"
-#. Launching slam_toolbox - in logs wait for "Registering sensor"
-#. Launching Nav2 - in logs wait for "Creating bond timer"
+  #. Launching Description Nodes, RViz and Gazebo - in logs wait for "Connected to gazebo master"
+  #. Launching slam_toolbox - in logs wait for "Registering sensor"
+  #. Launching Nav2 - in logs wait for "Creating bond timer"
 
 Visualizing Costmaps in RViz
 ----------------------------

--- a/setup_guides/sensors/setup_sensors.rst
+++ b/setup_guides/sensors/setup_sensors.rst
@@ -505,6 +505,12 @@ Note that the parameters of the ``nav2_costmap_2d`` that we discussed in the pre
 
 After we have properly set up and launched Nav2, the ``/global_costmap`` and ``/local_costmap`` topics should now be active.
 
+Note: To make the costmaps show up, the 3 commands must be run in the right order
+
+#. Launching Description Nodes, RViz and Gazebo - in logs wait for "Connected to gazebo master"
+#. Launching slam_toolbox - in logs wait for "Registering sensor"
+#. Launching Nav2 - in logs wait for "Creating bond timer"
+
 Visualizing Costmaps in RViz
 ----------------------------
 


### PR DESCRIPTION
## Why
* For low compute, delays in startup makes processes start in the wrong order, resulting in malformed tf trees
* Resulting log messages direct towards solving different problems, but problems are only symptoms of this specific problem
* For beginners, prevent spending too much time guessing what the problem could be

## Symptom Errors
* Logs Timed out waiting for transform , frame does not exist
* RViz Global costmap No map received
* Message filter discarding message because queue is full