### PR TITLE
follow path exceptions

### DIFF
--- a/configuration/packages/bt-plugins/actions/FollowPath.rst
+++ b/configuration/packages/bt-plugins/actions/FollowPath.rst
@@ -65,6 +65,10 @@ Input Ports
   Description
     	Action server timeout (ms).
 
+
+Output Ports
+------------
+
 :follow_path_error_code:
 
   ============== =======

--- a/configuration/packages/bt-plugins/actions/FollowPath.rst
+++ b/configuration/packages/bt-plugins/actions/FollowPath.rst
@@ -65,6 +65,17 @@ Input Ports
   Description
     	Action server timeout (ms).
 
+:follow_path_error_code:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  int16          N/A  
+  ============== =======
+
+  Description
+    	Follow path error code.
+
 Example
 -------
 

--- a/configuration/packages/bt-plugins/actions/FollowPath.rst
+++ b/configuration/packages/bt-plugins/actions/FollowPath.rst
@@ -78,7 +78,7 @@ Output Ports
   ============== =======
 
   Description
-    	Follow path error code.
+    	Follow path error code. See ``FollowPath`` action for the enumerated set of error code definitions.
 
 Example
 -------

--- a/migration/Humble.rst
+++ b/migration/Humble.rst
@@ -53,16 +53,13 @@ Feedback for Navigation Failures
 
 The following errors codes are supported (with more to come as necessary): Unknown, TF Error, Start or Goal Outside of Map, Start or Goal Occupied, Timeout, or No Valid Path Found.
 
+`PR #3227 <https://github.com/ros-planning/navigation2/pull/3227>`_ updates the controllers to throw exceptions on failures. These exceptions get reported back to the controller server which in turn places a error code on the Behavior Tree Navigatior's blackboard for use in contextual error handling in the autonomy application. 
+
+The following error codes are supported (with more to come as necessary): Unknown, TF Error, Invalid Path, Patience Exceeded, Failed To Make Progress, or No Valid Control. 
+
 Costmap Filters
 ***************
 
 Costmap Filters now are have an ability to be enabled/disabled in run-time by calling ``toggle_filter`` service for appropriate filter (`PR #3229 <https://github.com/ros-planning/navigation2/pull/3229>`_).
 
 Added new binary flip filter, allowing e.g. to turn off camera in sensitive areas, turn on headlights/leds/other safety things or switch operating mode when robot is inside marked on mask areas (`PR #3228 <https://github.com/ros-planning/navigation2/pull/3228>`_).
-
-Feedback for Navigation Failures 2
-**********************************
-
-`PR #3227 <https://github.com/ros-planning/navigation2/pull/3227>`_ updates the controllers to throw exceptions on failures. These exceptions get reported back to the controller server which in turn places a error code on the Behavior Tree Navigatior's blackboard for use in contextual error handling in the autonomy application. 
-
-The following error codes are supported (with more to come as necessary): Unknown, TF Error, Invalid Path, Patience Exceeded, Failed To Make Progress, or No Valid Control. 

--- a/migration/Humble.rst
+++ b/migration/Humble.rst
@@ -59,3 +59,10 @@ Costmap Filters
 Costmap Filters now are have an ability to be enabled/disabled in run-time by calling ``toggle_filter`` service for appropriate filter (`PR #3229 <https://github.com/ros-planning/navigation2/pull/3229>`_).
 
 Added new binary flip filter, allowing e.g. to turn off camera in sensitive areas, turn on headlights/leds/other safety things or switch operating mode when robot is inside marked on mask areas (`PR #3228 <https://github.com/ros-planning/navigation2/pull/3228>`_).
+
+Feedback for Navigation Failures 2
+**********************************
+
+`PR #3227 <https://github.com/ros-planning/navigation2/pull/3227>`_ updates the controllers to throw exceptions on failures. These exceptions get reported back to the controller server which in turn places a error code on the Behavior Tree Navigatior's blackboard for use in contextual error handling in the autonomy application. 
+
+The following error codes are supported (with more to come as necessary): Unknown, TF Error, Invalid Path, Patience Exceeded, Failed To Make Progress, or No Valid Control. 


### PR DESCRIPTION
Documentation for [controller exceptions](https://github.com/ros-planning/navigation2/pull/3227). 