### PR TITLE
Add "static_layer" to the local map plugins

### DIFF
--- a/setup_guides/sensors/setup_sensors.rst
+++ b/setup_guides/sensors/setup_sensors.rst
@@ -373,7 +373,7 @@ In this subsection, we will show an example configuration of ``nav2_costmap_2d``
         height: 3
         resolution: 0.05
         robot_radius: 0.22
-        plugins: ["voxel_layer", "inflation_layer"]
+        plugins: ["voxel_layer", "inflation_layer", "static_layer"]
         voxel_layer:
           plugin: "nav2_costmap_2d::VoxelLayer"
           enabled: True


### PR DESCRIPTION
the omission of static layer made impossible to generate and visualize the local map on rviz. Thanks to Giacomo Fanti @FantiG for finding the error