### PR TITLE
Fix planner_server parameters config example

### DIFF
--- a/plugin_tutorials/docs/writing_new_nav2planner_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_nav2planner_plugin.rst
@@ -196,26 +196,26 @@ To enable the plugin, we need to modify the ``nav2_params.yaml`` file as belowto
 .. code-block:: text
 
   planner_server:
-  ros__parameters:
-    plugins: ["GridBased"]
-    use_sim_time: True
-    GridBased:
-      plugin: nav2_navfn_planner/NavfnPlanner # For Foxy and later
-      tolerance: 2.0
-      use_astar: false
-      allow_unknown: true
+    ros__parameters:
+      plugins: ["GridBased"]
+      use_sim_time: True
+      GridBased:
+        plugin: "nav2_navfn_planner/NavfnPlanner" # For Foxy and later
+        tolerance: 2.0
+        use_astar: false
+        allow_unknown: true
 
 with
 
 .. code-block:: text
 
   planner_server:
-  ros__parameters:
-    plugins: ["GridBased"]
-    use_sim_time: True
-    GridBased:
-      plugin: nav2_straightline_planner/StraightLine
-      interpolation_resolution: 0.1
+    ros__parameters:
+      plugins: ["GridBased"]
+      use_sim_time: True
+      GridBased:
+        plugin: "nav2_straightline_planner/StraightLine"
+        interpolation_resolution: 0.1
 
 In the above snippet, you can observe the mapping of our ``nav2_straightline_planner/StraightLine`` planner to its id ``GridBased``. To pass plugin-specific parameters we have used ``<plugin_id>.<plugin_specific_parameter>``.
 


### PR DESCRIPTION
- Fix indentation in planner_server parameters
- Fix plugin by adding quotes "nav2_straightline_planner/StraightLine" and "nav2_navfn_planner/NavfnPlanner" Currently the presented configuration has wrong indentation which causes these error messages:

```
[planner_server-3] [ERROR] [1678443929.379055702] [rcl]: Failed to parse global arguments
[planner_server-3] terminate called after throwing an instance of 'rclcpp::exceptions::RCLInvalidROSArgsError'
[planner_server-3]   what():  failed to initialize rcl: Couldn't parse params file: '--params-file /home/user/ros2_ws/install/path_planner_server/share/path_planner_server/config/planner_server.yaml'. Error: Cannot have a value before ros__parameters at line 12, at /tmp/binarydeb/ros-galactic-rcl-yaml-param-parser-3.1.3/src/parse.c:793, at /tmp/binarydeb/ros-galactic-rcl-3.1.3/src/rcl/arguments.c:406
```

Correct indentation shows expected output:
```
[planner_server-3] [INFO] [1678444203.186597809] [planner_server]:
[planner_server-3]      planner_server lifecycle node launched.
[planner_server-3]      Waiting on external lifecycle transitions to activate
[planner_server-3]      See https://design.ros2.org/articles/node_lifecycle.html for more information.
[planner_server-3] [INFO] [1678444203.220639494] [planner_server]: Creating
```