### PR TITLE
update documentation for publishing collision monitor state

### DIFF
--- a/configuration/packages/configuring-collision-monitor.rst
+++ b/configuration/packages/configuring-collision-monitor.rst
@@ -383,6 +383,7 @@ For more information how to bring-up your own Collision Monitor node, please ref
         odom_frame_id: "odom"
         cmd_vel_in_topic: "cmd_vel_raw"
         cmd_vel_out_topic: "cmd_vel"
+        state_topic: "collision_monitor_state"
         transform_tolerance: 0.5
         source_timeout: 5.0
         base_shift_correction: True

--- a/configuration/packages/configuring-collision-monitor.rst
+++ b/configuration/packages/configuring-collision-monitor.rst
@@ -91,6 +91,17 @@ Parameters
   Description:
     Output ``cmd_vel`` topic with output produced by Collision Monitor velocities.
 
+:state_topic:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  string         ""
+  ============== =============================
+
+  Description:
+    Output the currently activated polygon action type and name. Optional parameter. No publisher will be created if it is unspecified.
+
 :transform_tolerance:
 
   ============== =============================

--- a/migration/Humble.rst
+++ b/migration/Humble.rst
@@ -172,3 +172,8 @@ More stable regulation on curves for long lookahead distances
 *************************************************************
 
 `PR #3414 <https://github.com/ros-planning/navigation2/pull/3414>`_ adds a new ``use_fixed_curvature_lookahead`` parameter to the RPP controller. This makes slowing down on curve not dependent on the instantaneous lookahead point, but instead on a fixed distance set by the parameter ``curvature_lookahead_dist``.
+
+Publish Collision Monitor State
+*************************************************************
+
+`PR #3504 <https://github.com/ros-planning/navigation2/pull/3504>`_ adds a new ``state_topic`` parameter to the CollisionMonitor. If specified, this optional parameter enables the state topic publisher. The topic reports the currently activated polygon action type and name.

--- a/migration/Humble.rst
+++ b/migration/Humble.rst
@@ -174,6 +174,6 @@ More stable regulation on curves for long lookahead distances
 `PR #3414 <https://github.com/ros-planning/navigation2/pull/3414>`_ adds a new ``use_fixed_curvature_lookahead`` parameter to the RPP controller. This makes slowing down on curve not dependent on the instantaneous lookahead point, but instead on a fixed distance set by the parameter ``curvature_lookahead_dist``.
 
 Publish Collision Monitor State
-*************************************************************
+*******************************
 
 `PR #3504 <https://github.com/ros-planning/navigation2/pull/3504>`_ adds a new ``state_topic`` parameter to the CollisionMonitor. If specified, this optional parameter enables the state topic publisher. The topic reports the currently activated polygon action type and name.


### PR DESCRIPTION
Added documentation for the new `state_topic` parameter in Collision Monitor. Please let me know if I missed out anything important to update!