### PR TITLE
Update navigation with SLAM tutorial path

### DIFF
--- a/tutorials/docs/navigation2_on_real_turtlebot3.rst
+++ b/tutorials/docs/navigation2_on_real_turtlebot3.rst
@@ -54,7 +54,7 @@ You will need to launch your robot's interface,
 You need to have a map of the environment where you want to Navigate Turtlebot 3, or create one live with SLAM.
 
 In case you are interested, there is a use case tutorial which shows how to use Nav2 with SLAM.
-`Nav2 with SLAM <https://github.com/ros-planning/navigation2/blob/main/doc/use_cases/navigation_with_slam.md>`_
+:ref:`navigation2-with-slam`.
 
 Required files:
 


### PR DESCRIPTION
The link for [Nav2 with SLAM](https://navigation.ros.org/tutorials/docs/navigation2_with_slam.html) in [Navigating with a Physical Turtlebot 3](https://navigation.ros.org/tutorials/docs/navigation2_on_real_turtlebot3.html#launch-nav2) is borken. This PR to fix it. 