### PR TITLE
Remove tb3 manual install

### DIFF
--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -32,7 +32,7 @@ Installation
 
    .. code-block:: bash
 
-      sudo apt install ros-<ros2-distro>-turtlebot3*
+      sudo apt install ros-<ros2-distro>-turtlebot3-gazebo
 
 Running the Example
 *******************

--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -28,7 +28,7 @@ Installation
       sudo apt install ros-<ros2-distro>-navigation2
       sudo apt install ros-<ros2-distro>-nav2-bringup
 
-3. Install the Turtlebot 3 packages:
+3. Install the Turtlebot 3 packages (Humble and older):
 
    .. code-block:: bash
 


### PR DESCRIPTION
* The necessary deps are now installed when you install nav2_bringup, or use rosdep
* Follow up to https://github.com/ros-planning/navigation2/pull/3556