### PR TITLE
Fix new controller plugin tutorial to latest Nav2 state

### DIFF
--- a/plugin_tutorials/docs/writing_new_nav2controller_plugin.rst
+++ b/plugin_tutorials/docs/writing_new_nav2controller_plugin.rst
@@ -80,7 +80,6 @@ The list of methods, and their descriptions, and necessity are presented in the 
 |                           | behavior to be untouched.                                                             |                        |
 +---------------------------+---------------------------------------------------------------------------------------+------------------------+
 
-
 In this tutorial, we will have used the methods ``PurePursuitController::configure``, ``PurePursuitController::setPlan`` and
 ``PurePursuitController::computeVelocityCommands``.
 


### PR DESCRIPTION
The fix of https://github.com/ros-planning/navigation.ros.org/issues/423 issue request contains updates to the latest Nav2 status for controller plugins.

This includes:
* Added `setSpeedLimit`, introduced in https://github.com/ros-planning/navigation2/commit/6a0c92cad7fb8bb1e3e8500742bc293cddbedc36 and https://github.com/ros-planning/navigation2/commit/992deb0ff740e60189234455ac8c372fcaf2759c
* Added goal checker to the `computeVelocityCommands()` signature (and one sentence description) after https://github.com/ros-planning/navigation2/commit/d8bd3c5ea8d196ad7f0bace1edaeaa8e55f06944
* Update `configure()` signature, changed after https://github.com/ros-planning/navigation2/commit/4d596b91dcad20e61e67b9261a8200fc546af6f3 commit