### PR TITLE
Change Sphinx project name to 'Nav2'

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -63,7 +63,7 @@ source_suffix = ['.rst', '.md']
 master_doc = 'index'
 
 # General information about the project.
-project = u'Navigation 2'
+project = u'Nav2'
 copyright = u'2020'
 author = u'Various'
 


### PR DESCRIPTION
The Sphinx project name appears in the top left of every page.

Before:

![Screenshot from 2023-08-29 11-33-29](https://github.com/ros-planning/navigation.ros.org/assets/3717345/9b3632b6-c16f-4736-880f-d02f87ef7e2f)

After:

![Screenshot from 2023-08-29 11-33-23](https://github.com/ros-planning/navigation.ros.org/assets/3717345/ba200ac7-6e2d-4550-9198-507e2cf0c2a8)