### PR TITLE
Fix misprint in PR link

### DIFF
--- a/migration/Iron.rst
+++ b/migration/Iron.rst
@@ -82,4 +82,4 @@ RewrittenYaml could add new parameters to YAMLs
 ***********************************************
 
 Now ``RewrittenYaml`` widely used in Nav2 launch-scripts, could do not only substitutions of ROS-parameters existing in original YAML, but rather additions of new parameters, that did not exist in the YAML. Certainly, these parameters should be declared for target ROS-nodes, otherwise they won't be processed in run-time. In such functionality, they should be expressed in absolute values, separated by a dot. For example, the rewrite for a ``prune_distance`` parameter of a ``FollowPath`` node will look like ``'controller_server.ros__parameters.FollowPath.prune_distance': '1.0'`` in a ``param_rewrites`` dictionary of ``RewrittenYaml()`` argument.
-The change was intoroduced in the scope of `PR #3785 <https://github.com/ros-planning/navigation2/pull/3785>` fix.
+The change was intoroduced in the scope of `PR #3785 <https://github.com/ros-planning/navigation2/pull/3785>`_ fix.


### PR DESCRIPTION
Fix misprint in PR link (forgotten underscore after link). Related to #462