### PR TITLE
Update requirements.txt to Ubuntu 22.04

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-breathe==4.28.0
-docutils==0.14
+breathe
+docutils==0.15
 jinja2==3.0.3
 myst-parser==1.0.0
 sphinx_copybutton==0.5.2
 sphinx_rtd_theme
 sphinx-autobuild
-sphinx==3.5.0
+sphinx==5.3.0
 sphinxcontrib-plantuml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-breathe
+breathe==4.35.0
 docutils==0.15
 jinja2==3.0.3
 myst-parser==1.0.0


### PR DESCRIPTION
## Proposed solution

This is attempt to fix the #364 , which `requirements.txt` is out of date for Ubuntu 22.04.
The following pip3 requirements were updated (empty fields in columns 2 and 3 mean that package version is unspecified):

| Package  | Vanilla | New | Changed | Rationale |
| ------------- | ------------- | --- | --- | --- |
| breathe | 4.28.0 | 4.35.0 | Y | breathe `4.28.0` is incompatible with Sphinx above `v3.6`, so updating the version and fix it to the currently working `4.35.0` |
| docutils | 0.14 | 0.15 | Y | myst-parser 1.0.0 requires `0.15<=docutils<0.20`. The docutils version can not be relaxed, as `sphinx 5.3.0`, `myst-parser 1.0.0` and `sphinx-rtd-theme` have restrictions from above on the upper version of it, so switching it to the next sub-version. |
| jinja2 | 3.0.3 | 3.0.3 | N | |
| myst-parser | 1.0.0 | 1.0.0 | N | Available versions of myst-parser are 1.0.0 and 2.0.0, but I'd suppose for the compatibility purposes is better to not update this verision to 2.0.0 |
| sphinx_copybutton | 0.5.2 | 0.5.2 | N | |
| sphinx_rtd_theme |  |  | N | |
| sphinx-autobuild |  |  | N | |
| sphinx | 3.5.0 | 5.3.0 | Y | Fix for https://github.com/sphinx-doc/sphinx/issues/9562 requires Sphinx at least `v4.2.0`. However, myst-parser 1.0.0 requires `5<=sphinx<7` and latest breathe (4.35.0) is not compatible with `Sphinx==5.0.0`, so choosing latest Sphinx of version 5 line, which is `5.3.0` |
| sphinxcontrib-plantuml |  |  | N | |

## Verification results

Tested on local Ubuntu 22.04 machine and `ubuntu:focal` Docker container locally repeating CircleCI steps and configuration.

Pip3 install and make html logs on Docker container with vanilla `requirements.txt` are attached below:
[pip3_install_vanilla.log](https://github.com/ros-planning/navigation.ros.org/files/12597260/pip3_install_vanilla.log)
[make_html_vanilla.log](https://github.com/ros-planning/navigation.ros.org/files/12597268/make_html_vanilla.log)

There is the following issue appear on Ubuntu 20.04:
```
ERROR: myst-parser 1.0.0 has requirement docutils<0.20,>=0.15, but you'll have docutils 0.14 which is incompatible.
ERROR: myst-parser 1.0.0 has requirement sphinx<7,>=5, but you'll have sphinx 3.5.0 which is incompatible.
```

The same error messages are also observed on CircleCI ("Install Doc Dependencies" phase):
https://app.circleci.com/pipelines/github/ros-planning/navigation.ros.org/1899/workflows/f70556c1-22e1-4320-8912-6e6fc427e52b/jobs/2208

Logs after applying the changes from above requirements table, are listed here:
[pip3_install_new.log](https://github.com/ros-planning/navigation.ros.org/files/12597282/pip3_install_new.log)
[make_html_new.log](https://github.com/ros-planning/navigation.ros.org/files/12597283/make_html_new.log)

All error messages on `pip3 install` phase were disappeared.
On `make html` stage one new warning message appear:
```
WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
```
This message was introduced in Sphinx 4.0 (https://www.sphinx-doc.org/en/master/changes.html#release-4-0-0-released-may-09-2021) and thus will be appeared in any Sphinx update configuration. This is not critical issue for now and requires an attention on next Sphinx 6++ version update, I suppose.
The documentation build passes and generates HTML well for the new configuration.