### PR TITLE
Enable goals to be sent in other frames than the pre-configured global_frame (documentation)

### DIFF
--- a/configuration/packages/bt-plugins/actions/RemovePassedGoals.rst
+++ b/configuration/packages/bt-plugins/actions/RemovePassedGoals.rst
@@ -20,17 +20,6 @@ Input Ports
   Description
     The radius (m) in proximity to the viapoint for the BT node to remove from the list as having passed. 
 
-:global_frame:
-
-  ====== =======
-  Type   Default
-  ------ -------
-  string "map"
-  ====== =======
-
-  Description
-    Reference frame.
-
 :robot_base_frame:
 
   ====== ===========

--- a/configuration/packages/bt-plugins/conditions/GoalReached.rst
+++ b/configuration/packages/bt-plugins/conditions/GoalReached.rst
@@ -48,17 +48,7 @@ Input Ports
 
   Description
     	Destination to check. Takes in a blackboard variable, e.g. "{goal}".
-
-:global_frame:
-
-  ====== =======
-  Type   Default
-  ------ -------
-  string "map"
-  ====== =======
-
-  Description
-    	Reference frame.
+    	The global reference frame is taken from the goal's header `frame_id` field.
 
 :robot_base_frame:
 
@@ -76,4 +66,4 @@ Example
 
 .. code-block:: xml
 
-  <GoalReached goal="{goal}" global_frame="map" robot_base_frame="base_link"/>
+  <GoalReached goal="{goal}" robot_base_frame="base_link"/>


### PR DESCRIPTION
Remove `global_frame` input port from the `GoalReached` and `RemovePassedGoals` behavior nodes. Related to https://github.com/ros-planning/navigation2/pull/3917.