### PR TITLE
Feature/add ability visualize the state lattice tree expansions

### DIFF
--- a/configuration/packages/configuring-bt-navigator.rst
+++ b/configuration/packages/configuring-bt-navigator.rst
@@ -111,6 +111,18 @@ Parameters
     Default timeout value (in milliseconds) while a BT action node is waiting for acknowledgement from an action server.
     This value will be overwritten for a BT node if the input port "server_timeout" is provided.
 
+:wait_for_service_timeout:
+
+  ==== =======
+  Type Default
+  ---- -------
+  int  1000
+  ==== =======
+
+  Description
+    Default timeout value (in milliseconds) while a BT nodes are waiting for acknowledgement from an service server.
+    This value will be overwritten for a BT node if the input port "wait_for_service_timeout" is provided.
+    
 :action_server_result_timeout:
 
   ====== ======= ======= 

--- a/configuration/packages/smac/configuring-smac-lattice.rst
+++ b/configuration/packages/smac/configuring-smac-lattice.rst
@@ -28,6 +28,17 @@ Parameters
   Description
     Whether to allow traversing/search in unknown space.
 
+:``<name>``.debug_visualizations:
+
+  ====== =======
+  Type   Default                                                   
+  ------ -------
+  bool   false         
+  ====== =======
+
+  Description
+    Whether to publish expansions on the ``/expansions`` topic as an array of poses (the orientation has no meaning) and the path's footprints on the ``/planned_footprints`` topic. WARNING: heavy to compute and to display, for debug only as it degrades the performance.
+
 :``<name>``.tolerance:
 
   ====== =======


### PR DESCRIPTION
Update after: https://github.com/ros-planning/navigation2/pull/3997#issuecomment-1843787033