### PR TITLE
Document optional TwistStamped support

### DIFF
--- a/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
+++ b/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
@@ -194,6 +194,18 @@ Parameters
   Description
     Adds soft real-time priorization to the controller server to better ensure resources to time sensitive portions of the codebase. This will set the controller's execution thread to a higher priority than the rest of the system (``90``) to meet scheduling deadlines to have less missed loop rates. To use this feature, you use set the following inside of ``/etc/security/limits.conf`` to give userspace access to elevated prioritization permissions: ``<username> soft rtprio 99 <username> hard rtprio 99``
 
+:enable_stamped_cmd_vel:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description
+    Whether to use geometry_msgs::msg::Twist or geometry_msgs::msg::TwistStamped velocity data.
+    True uses TwistStamped, false uses Twist.
+
 Polygons parameters
 ===================
 
@@ -465,6 +477,7 @@ Here is an example of configuration YAML for the Collision Monitor.
         source_timeout: 5.0
         base_shift_correction: True
         stop_pub_timeout: 2.0
+        enable_stamped_cmd_vel: False
         use_realtime_priority: false
         polygons: ["PolygonStop", "PolygonSlow", "FootprintApproach"]
         PolygonStop:

--- a/configuration/packages/configuring-behavior-server.rst
+++ b/configuration/packages/configuring-behavior-server.rst
@@ -226,6 +226,19 @@ Spin distance is given from the action request
   Description
     maximum rotational acceleration (rad/s^2).
 
+:enable_stamped_cmd_vel:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description
+    Whether to use geometry_msgs::msg::Twist or geometry_msgs::msg::TwistStamped velocity data.
+    True uses TwistStamped, false uses Twist.
+
+
 BackUp Behavior Parameters
 **************************
 
@@ -257,6 +270,19 @@ DriveOnHeading distance, speed and time_allowance is given from the action reque
 
   Description
     Time to look ahead for collisions (s).
+
+:enable_stamped_cmd_vel:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description
+    Whether to use geometry_msgs::msg::Twist or geometry_msgs::msg::TwistStamped velocity data.
+    True uses TwistStamped, false uses Twist.
+
 
 AssistedTeleop Behavior Parameters
 **********************************
@@ -296,6 +322,18 @@ AssistedTeleop time_allowance is given in the action request
   Description
     Topic to listen for teleop messages.
 
+:enable_stamped_cmd_vel:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description
+    Whether to use geometry_msgs::msg::Twist or geometry_msgs::msg::TwistStamped velocity data.
+    True uses TwistStamped, false uses Twist.
+
 Example
 *******
 .. code-block:: yaml
@@ -326,3 +364,4 @@ Example
         max_rotational_vel: 1.0
         min_rotational_vel: 0.4
         rotational_acc_lim: 3.2
+        enable_stamped_cmd_vel: false

--- a/configuration/packages/configuring-controller-server.rst
+++ b/configuration/packages/configuring-controller-server.rst
@@ -194,6 +194,17 @@ Parameters
   Description
     Topic to get instantaneous measurement of speed from.
 
+:enable_stamped_cmd_vel:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description
+    Whether to use geometry_msgs::msg::Twist or geometry_msgs::msg::TwistStamped velocity data.
+    True uses TwistStamped, false uses Twist.
 
 Provided Plugins
 ****************

--- a/configuration/packages/configuring-velocity-smoother.rst
+++ b/configuration/packages/configuring-velocity-smoother.rst
@@ -148,6 +148,19 @@ Velocity Smoother Parameters
   Description
     Time (s) to buffer odometry commands to estimate the robot speed, if in ``CLOSED_LOOP`` operational mode.
 
+:enable_stamped_cmd_vel:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description
+    Whether to use geometry_msgs::msg::Twist or geometry_msgs::msg::TwistStamped velocity data.
+    True uses TwistStamped, false uses Twist.
+
+
 Example
 *******
 .. code-block:: yaml
@@ -166,3 +179,4 @@ Example
       odom_topic: "odom"
       odom_duration: 0.1
       use_realtime_priority: false
+      enable_stamped_cmd_vel: false

--- a/tutorials/docs/using_collision_monitor.rst
+++ b/tutorials/docs/using_collision_monitor.rst
@@ -86,6 +86,7 @@ The whole ``nav2_collision_monitor/params/collision_monitor_params.yaml`` file i
         transform_tolerance: 0.5
         source_timeout: 5.0
         stop_pub_timeout: 2.0
+        enable_stamped_cmd_vel: False
         polygons: ["PolygonStop", "PolygonSlow"]
         PolygonStop:
           type: "polygon"


### PR DESCRIPTION
To be merged with https://github.com/ros-planning/navigation2/pull/3775.


Many of the behaviors inherit from TimedBehavior. Is it worth documenting the same parameter in all of them, or is there a better place to reduce docs duplication? 