### PR TITLE
Fix installation for rolling

### DIFF
--- a/development_guides/build_docs/index.rst
+++ b/development_guides/build_docs/index.rst
@@ -83,24 +83,21 @@ Building Nav2 using rolling development source is similar to building Nav2 from 
 
   * `ROS 2 Building from source <https://docs.ros.org/en/rolling/Installation.html#building-from-source>`_
 
-Once your environment is setup, clone the repo, import all dependencies, and build the workspace:
-
-.. attention::
-   Be sure to check that all dependencies you need are included and uncommented in the ``.repos`` file.
+Once your environment is setup, clone the repo and build the workspace:
 
 .. code:: bash
 
   source <ros_ws>/install/setup.bash
   mkdir -p ~/nav2_ws/src && cd ~/nav2_ws
-  git clone https://github.com/ros-planning/navigation2.git --branch $ROS_DISTRO ./src/navigation2
-  vcs import ./src < ./src/navigation2/tools/underlay.repos
-  rosdep install -y \
+  git clone https://github.com/ros-planning/navigation2.git --branch main ./src/navigation2
+  rosdep install -r -y \
     --from-paths ./src \
     --ignore-src
   colcon build \
     --symlink-install
 
-You can then ``source ~/nav2_ws/install/setup.bash`` to get ready for demonstrations!
+You can then ``source ~/nav2_ws/install/setup.bash`` to get ready for demonstrations! It is safe
+to ignore the rosdep error of from the missing ``slam_toolbox`` key.
 
 .. hint::
   For more examples on building Nav2 from rolling development source, checkout `source.Dockerfile <https://github.com/ros-planning/navigation2/blob/main/tools/source.Dockerfile>`_.

--- a/development_guides/build_docs/index.rst
+++ b/development_guides/build_docs/index.rst
@@ -77,6 +77,7 @@ Rolling Development Source
 ==========================
 
 Building Nav2 using rolling development source is similar to building Nav2 from released distribution binaries, where instead you build dependencies from source using the main development branches for all ROS based packages.
+Nav2 does not currently release binaries on rolling, so it must be build from source.
 
 .. seealso::
   For more information on building ROS 2 from source, see the official documentation:


### PR DESCRIPTION
# Purpose

* Use the correct branch
* Don't pull in vcs sources for geometry2
* Handle slam_toolbox circular dependency in the background automatically
* Add note that binaries are not available for rolling. If this changes, then a new section can be added
* Be able to compile NAV2 on rolling following the instructions verbatim without errors

# How to test

Use this dockerfile:
```
ARG ROS_DISTRO=rolling
FROM ros:${ROS_DISTRO}-ros-core

RUN apt-get update \
    && apt-get install -y \
        ros-dev-tools \
        wget
        
WORKDIR /root/ros2_ws 
RUN mkdir -p ~/ros2_ws/src
RUN git clone https://github.com/ros-planning/navigation2.git --branch main ./src/navigation2
RUN rosdep init

SHELL ["/bin/bash", "-c"]
RUN apt-get update \
    && rosdep update \
    && source /opt/ros/${ROS_DISTRO}/setup.bash \
    && rosdep install -y -r --ignore-src --from-paths src

RUN source /opt/ros/${ROS_DISTRO}/setup.bash \ 
    && colcon build --symlink-install
```

ANd run
`docker build .`

Note - because it's rolling, this may not be reproducible, but it works today.
