### PR TITLE
Collision monitor transient local sub new param

### DIFF
--- a/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
+++ b/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
@@ -265,7 +265,7 @@ Polygons parameters
   ============== ===================================
 
   Description:
-    QoS durability setting for polygon topic or for footprint topic subscription.
+    QoS durability setting for the incoming polygon or footprint topic subscription.
 
 :``<polygon_name>``.radius:
 

--- a/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
+++ b/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
@@ -256,6 +256,17 @@ Polygons parameters
   Description:
     Topic to listen the robot footprint from. Applicable only for ``polygon`` type and ``approach`` action type. If both ``points`` and ``footprint_topic`` are specified, the static ``points`` takes priority.
 
+:``<polygon_name>``.polygon_subscribe_transient_local:
+
+  ============== ===================================
+  Type           Default
+  -------------- -----------------------------------
+  bool           False
+  ============== ===================================
+
+  Description:
+    QoS durability setting for polygon topic or for footprint topic subscription.
+
 :``<polygon_name>``.radius:
 
   ============== =============================

--- a/migration/Iron.rst
+++ b/migration/Iron.rst
@@ -294,3 +294,8 @@ New BtActionServer/BtNavigator parameter
 
 `PR #4209 <https://github.com/ros-planning/navigation2/pull/4209>`_ introduces a new boolean parameter ``always_reload_bt_xml``, which enables the possibility to always reload a requested behavior tree XML description, regardless of the currently active XML. This allows keeping the action server running while changing/developing the XML description.
 
+
+New collision monitor parameter
+*******************************
+
+`PR #4207 <https://github.com/ros-planning/navigation2/pull/4207>`_ introduces a new boolean parameter ``polygon_subscribe_transient_local`` (value is false by default), which set the QoS durability for polygon topic or footprint topic subscription.


### PR DESCRIPTION
Update collision_monitor configuration guide and migration guide with description of new parameter `<polygon_name>.polygon_subscribe_transient_local` introduced by PR https://github.com/ros-planning/navigation2/pull/4207.