### PR TITLE
Typo on detailed_behavior_tree_walkthrough.rst

### DIFF
--- a/behavior_trees/overview/detailed_behavior_tree_walkthrough.rst
+++ b/behavior_trees/overview/detailed_behavior_tree_walkthrough.rst
@@ -237,7 +237,7 @@ If at any point the goal gets updated, this subtree will halt all children and r
 This should look familiar to the contextual recovery portions of the ``Navigation`` subtree. This is a common BT pattern to handle the situation "Unless 'this condition' happens, Do action A".
 
 These condition nodes can be extremely powerful and are typically paired with ``ReactiveFallback``. It can be easy to imagine wrapping this whole ``navigate_to_pose_w_replanning_and_recovery`` tree
-in a ``ReactiveFallback`` with a ``isBatteryLow`` condition -- meaning the ``navigate_to_pose_w_replanning_and_recovery`` tree will execute *unless* the battery becomes low (and then entire a different subtree for docking to recharge).
+in a ``ReactiveFallback`` with a ``isBatteryLow`` condition -- meaning the ``navigate_to_pose_w_replanning_and_recovery`` tree will execute *unless* the battery becomes low (and then enter a different subtree for docking to recharge).
 
 If the goal is never updated, the behavior tree will go on to the ``RoundRobin`` node. These are the default four system-level recoveries in the BT are:
 


### PR DESCRIPTION
Replaced

tree will execute *unless* the battery becomes low (and then ***entire*** a different subtree for docking to recharge).

tree will execute *unless* the battery becomes low (and then ***enter*** a different subtree for docking to recharge).