### PR TITLE
Replace incorrect 'arguments' with 'parameters' 2

### DIFF
--- a/setup_guides/urdf/setup_urdf.rst
+++ b/setup_guides/urdf/setup_urdf.rst
@@ -220,7 +220,7 @@ Next, let us create our launch file. Launch files are used by ROS 2 to bring up 
           package='joint_state_publisher',
           executable='joint_state_publisher',
           name='joint_state_publisher',
-          arguments=[default_model_path],
+          parameters=[{'robot_description': Command(['xarcro ', default_model_path])}],
           condition=launch.conditions.UnlessCondition(LaunchConfiguration('gui'))
       )
       joint_state_publisher_gui_node = launch_ros.actions.Node(


### PR DESCRIPTION
Improved pull request for #548.

Launching this code with the option 'gui:=False' gives errors in RVIZ. The correct way of using parameters in the code is 'parameters' argument. The argument 'arguments' is for command line arguments.