### PR TITLE
replaced <ros2-distro> with $ROS_DISTRO

### DIFF
--- a/development_guides/build_docs/build_troubleshooting_guide.rst
+++ b/development_guides/build_docs/build_troubleshooting_guide.rst
@@ -9,7 +9,7 @@ Common Nav2 Dependencies Build Failures
 * Make sure that .bashrc file has no ROS environment variables in it. Open new terminals and try to build the packages again.
 
 * Make sure to run rosdep for the correct ROS 2 distribution.
-  ``rosdep install -y -r -q --from-paths src --ignore-src --rosdistro <ros2-distro>``
+  ``rosdep install -y -r -q --from-paths src --ignore-src --rosdistro $ROS_DISTRO``
 
 * Make sure that the ``setup.bash`` is sourced in the ROS 2 installation or ROS 2 main build workspace, if applicable. Check if you can run talker and listener nodes.
 

--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -28,8 +28,8 @@ Thus, for Jazzy and newer, the installation packages and instructions are slight
 
    .. code-block:: bash
 
-      sudo apt install ros-<ros2-distro>-navigation2
-      sudo apt install ros-<ros2-distro>-nav2-bringup
+      sudo apt install ros-$ROS_DISTRO-navigation2
+      sudo apt install ros-$ROS_DISTRO-nav2-bringup
 
 3. Install the demo robot (Turtlebot) for gazebo:
 
@@ -37,14 +37,14 @@ For **Jazzy and newer**, install the Turtlebot 3 & 4 packages for Gazebo Modern.
 
    .. code-block:: bash
 
-      sudo apt install ros-<ros2-distro>-nav2-minimal-tb*
+      sudo apt install ros-$ROS_DISTRO-nav2-minimal-tb*
 
 
 For **Iron and older**, install Turtlebot 3 packages for gazebo classic:
 
    .. code-block:: bash
 
-      sudo apt install ros-<ros2-distro>-turtlebot3-gazebo
+      sudo apt install ros-$ROS_DISTRO-turtlebot3-gazebo
 
 Running the Example
 *******************
@@ -54,9 +54,9 @@ Running the Example
 
    .. code-block:: bash
 
-      source /opt/ros/<ros2-distro>/setup.bash
+      source /opt/ros/$ROS_DISTRO/setup.bash
       export TURTLEBOT3_MODEL=waffle  # Iron and older only with Gazebo Classic
-      export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/<ros2-distro>/share/turtlebot3_gazebo/models # Iron and older only with Gazebo Classic
+      export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/$ROS_DISTRO/share/turtlebot3_gazebo/models # Iron and older only with Gazebo Classic
 
 3. In the same terminal, run:
 

--- a/setup_guides/odom/setup_odom_gz.rst
+++ b/setup_guides/odom/setup_odom_gz.rst
@@ -81,7 +81,7 @@ Setup and Prerequisites
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-ros-gz
+  sudo apt install ros-$ROS_DISTRO-ros-gz
 
 Adding Gazebo Plugins to a URDF/SDF
 ===================================

--- a/setup_guides/odom/setup_odom_gz_classic.rst
+++ b/setup_guides/odom/setup_odom_gz_classic.rst
@@ -81,7 +81,7 @@ We also need to install the ``gazebo_ros_pkgs`` package to simulate odometry and
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-gazebo-ros-pkgs
+  sudo apt install ros-$ROS_DISTRO-gazebo-ros-pkgs
 
 You can test if you have successfully set up your ROS 2 and Gazebo environments by following the instructions `given here <http://gazebosim.org/tutorials?tut=ros2_installing&cat=connect_ros#TestingGazeboandROS2integration>`_.
 

--- a/setup_guides/odom/setup_robot_localization.rst
+++ b/setup_guides/odom/setup_robot_localization.rst
@@ -29,7 +29,7 @@ First, install the ``robot_localization`` package using your machines package ma
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-robot-localization
+  sudo apt install ros-$ROS_DISTRO-robot-localization
 
 Next, we specify the parameters of the ``ekf_node`` using a YAML file. Create a directory named ``config`` at the root of your project and create a file named ``ekf.yaml``. Copy the following lines of code into your ``ekf.yaml`` file.
 

--- a/setup_guides/sdf/setup_sdf.rst
+++ b/setup_guides/sdf/setup_sdf.rst
@@ -17,7 +17,7 @@ We can also use our SDF with the robot_state_publisher using the following packa
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-sdformat-urdf
+  sudo apt install ros-$ROS_DISTRO-sdformat-urdf
 
 This package contains a C++ library and urdf_parser_plugin for converting SDFormat XML into URDF C++ structures. Installing it allows one to use SDFormat XML instead of URDF XML as a robot description.
 

--- a/setup_guides/sensors/mapping_localization.rst
+++ b/setup_guides/sensors/mapping_localization.rst
@@ -167,7 +167,7 @@ To be able to launch ``slam_toolbox``, make sure that you have installed the ``s
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-slam-toolbox
+  sudo apt install ros-$ROS_DISTRO-slam-toolbox
 
 We will launch the ``async_slam_toolbox_node`` of ``slam_toolbox`` using the package's built-in launch files. Open a new terminal and then execute the following lines:
 
@@ -199,8 +199,8 @@ First, Make sure you have installed the Nav2 packages by executing the following
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-navigation2
-  sudo apt install ros-<ros2-distro>-nav2-bringup
+  sudo apt install ros-$ROS_DISTRO-navigation2
+  sudo apt install ros-$ROS_DISTRO-nav2-bringup
 
 We will now launch Nav2 using the ``nav2_bringup``'s built-in launch file, ``navigation_launch.py`` . Open a new terminal and execute the following:
 

--- a/setup_guides/urdf/setup_urdf.rst
+++ b/setup_guides/urdf/setup_urdf.rst
@@ -33,8 +33,8 @@ Let's begin by installing some additional ROS 2 packages that we will be using d
 
 .. code-block:: shell
 
-  sudo apt install ros-<ros2-distro>-joint-state-publisher-gui
-  sudo apt install ros-<ros2-distro>-xacro
+  sudo apt install ros-$ROS_DISTRO-joint-state-publisher-gui
+  sudo apt install ros-$ROS_DISTRO-xacro
  
 Next, create a directory for your project, initialize a ROS 2 workspace and give your robot a name. For ours, we'll be calling it ``sam_bot``.
 

--- a/tutorials/docs/camera_calibration.rst
+++ b/tutorials/docs/camera_calibration.rst
@@ -18,16 +18,16 @@ Requirements
 
 1- Install Camera Calibration Parser, Camera Info Manager and Launch Testing Ament Cmake using operating system’s package manager:
 
-        ``sudo apt install ros-<ros2-distro>-camera-calibration-parsers``
+        ``sudo apt install ros-$ROS_DISTRO-camera-calibration-parsers``
 
-        ``sudo apt install ros-<ros2-distro>-camera-info-manager``
+        ``sudo apt install ros-$ROS_DISTRO-camera-info-manager``
 
-        ``sudo apt install ros-<ros2-distro>-launch-testing-ament-cmake``
+        ``sudo apt install ros-$ROS_DISTRO-launch-testing-ament-cmake``
 
 
 2- Image Pipeline need to be built from source in your workspace with:
 
-        ``git clone -b <ros2-distro> git@github.com:ros-perception/image_pipeline.git``
+        ``git clone -b $ROS_DISTRO git@github.com:ros-perception/image_pipeline.git``
 
 
 **Also, make sure you have the following:**

--- a/tutorials/docs/navigation2_on_real_turtlebot3.rst
+++ b/tutorials/docs/navigation2_on_real_turtlebot3.rst
@@ -34,7 +34,7 @@ The turtlebot3 software can be installed via the following or on the `turtlebot3
 
 .. code-block:: bash
 
-  sudo apt install ros-<ros2-distro>-turtlebot3 ros-<ros2-distro>-turtlebot3-msgs ros-<ros2-distro>-turtlebot3-bringup
+  sudo apt install ros-$ROS_DISTRO-turtlebot3 ros-$ROS_DISTRO-turtlebot3-msgs ros-$ROS_DISTRO-turtlebot3-bringup
 
 Tutorial Steps
 ==============
@@ -44,7 +44,7 @@ Tutorial Steps
 
 Run the following commands first whenever you open a new terminal during this tutorial.
 
-- ``source /opt/ros/<ros2-distro>/setup.bash``
+- ``source /opt/ros/$ROS_DISTRO/setup.bash``
 - ``export TURTLEBOT3_MODEL=waffle``
 
 1- Launch Turtlebot 3

--- a/tutorials/docs/navigation2_with_gps.rst
+++ b/tutorials/docs/navigation2_with_gps.rst
@@ -30,7 +30,7 @@ It is assumed ROS2 and Nav2 dependent packages are installed or built locally. A
 
    .. code-block:: bash
 
-      source /opt/ros/<ros2-distro>/setup.bash
+      source /opt/ros/$ROS_DISTRO/setup.bash
       sudo apt install ros-$ROS_DISTRO-robot-localization
       sudo apt install ros-$ROS_DISTRO-mapviz
       sudo apt install ros-$ROS_DISTRO-mapviz-plugins

--- a/tutorials/docs/navigation2_with_slam.rst
+++ b/tutorials/docs/navigation2_with_slam.rst
@@ -27,11 +27,11 @@ If you don't have them installed, please follow :ref:`getting_started`.
 
 SLAM Toolbox can be installed via:
 
-  ``sudo apt install ros-<ros2-distro>-slam-toolbox``
+  ``sudo apt install ros-$ROS_DISTRO-slam-toolbox``
 
 or from built from source in your workspace with:
 
-  ``git clone -b <ros2-distro>-devel git@github.com:stevemacenski/slam_toolbox.git``
+  ``git clone -b $ROS_DISTRO-devel git@github.com:stevemacenski/slam_toolbox.git``
 
 
 Tutorial Steps
@@ -45,14 +45,14 @@ The turtlebot3 software can be installed via the following or on the `turtlebot3
 
 .. code-block:: bash
 
-  sudo apt install ros-<ros2-distro>-turtlebot3 ros-<ros2-distro>-turtlebot3-msgs ros-<ros2-distro>-turtlebot3-bringup
+  sudo apt install ros-$ROS_DISTRO-turtlebot3 ros-$ROS_DISTRO-turtlebot3-msgs ros-$ROS_DISTRO-turtlebot3-bringup
 
 If you have another robot, replace with your robot specific interfaces.
 Typically, this includes the robot state publisher of the URDF, simulated or physical robot interfaces, controllers, safety nodes, and the like.
 
 Run the following commands first whenever you open a new terminal during this tutorial.
 
-- ``source /opt/ros/<ros2-distro>/setup.bash``
+- ``source /opt/ros/$ROS_DISTRO/setup.bash``
 - ``export TURTLEBOT3_MODEL=waffle``
 
 

--- a/tutorials/docs/navigation2_with_stvl.rst
+++ b/tutorials/docs/navigation2_with_stvl.rst
@@ -59,11 +59,11 @@ Follow the same process as in :ref:`getting_started` for installing and setting 
 
 STVL can be installed in ROS 2 via the ROS Build Farm:
 
-- ``sudo apt install ros-<ros2-distro>-spatio-temporal-voxel-layer``
+- ``sudo apt install ros-$ROS_DISTRO-spatio-temporal-voxel-layer``
 
 It can also be built from source by cloning the repository into your Navigation2 workspace:
 
-- ``git clone -b <ros2-distro>-devel git@github.com:stevemacenski/spatio_temporal_voxel_layer``
+- ``git clone -b $ROS_DISTRO-devel git@github.com:stevemacenski/spatio_temporal_voxel_layer``
 
 1- Modify Navigation2 Parameter
 -------------------------------


### PR DESCRIPTION
We have specified `<ros2-distro>` to refer to the ROS2 version, instead of which we can simply use $ROS_DISTRO, which would make it more copy-paste friendly.