### PR TITLE
Treat warnings as errors in sphinx builds.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,4 +67,4 @@ publish:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile doxy
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -W $(O)


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this *relates* to (not addresses)   | #775  #742|
---

## Description of contribution in a few bullet points

* Added a `-W` flag to treat warnings as errors.
* The idea is to prevent silent stylistic changes from getting to the codebase and failing them early in build.

## Describe how this change was tested

* Performed linting validation using `pre-commit run --all`
* Introduce a malformed table as in #775, and you would expect an error during `make html`.
