### PR TITLE
Update configuring-collision-monitor-node.rst

### DIFF
--- a/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
+++ b/configuration/packages/collision_monitor/configuring-collision-monitor-node.rst
@@ -582,7 +582,7 @@ Observation sources parameters
   ============== =============================
 
   Description:
-    Set true for pointcloud sources containing a "height" field relative to a real world ground contour. The "height" field will be used for the min and max height checks instead of the "z" field and will not be transformed with the rest of the cloud data. Applicable for ``pointcloud`` type.
+    Set true for pointcloud sources containing a "height" field relative to a real world ground contour. The "height" field will be used for the min and max height checks instead of the "z" field and will not be transformed as it is assumed that height is already global frame referenced. Applicable for ``pointcloud`` type.
 
 :``<source name>``.min_range:
 


### PR DESCRIPTION
Changes to support issue 5585 from the nav2 repo.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [(Nav2 #5585](https://github.com/ros-navigation/navigation2/issues/5585l)) |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

A use global height parameter was added to support point cloud data that contains a "height" field for calculation obstacle height. This is useful in operating domains where the ground surface is not flat or the robot is not always level to the surrounding ground level.
<!--
* Updated the documentation to reflect corresponding changes in navigation2.
* Reorganised some sections for better clarity.
-->
