### PR TITLE
Fix incorrect variables in documentation for Gazebo world and robot spawning 

### DIFF
--- a/setup_guides/odom/setup_odom_gz.rst
+++ b/setup_guides/odom/setup_odom_gz.rst
@@ -394,8 +394,8 @@ Add this two variables, which are needed for starting the Gazebo world and spawn
 
 .. code-block:: python
 
-  default_model_path = os.path.join(pkg_share, 'src', 'description', 'sam_bot_description.sdf')
-  default_rviz_config_path = os.path.join(pkg_share, 'rviz', 'config.rviz')
+  ros_gz_sim_share = get_package_share_directory('ros_gz_sim')
+  gz_spawn_model_launch_source = os.path.join(ros_gz_sim_share, "launch", "gz_spawn_model.launch.py")
 
 To make ``robot_state_publisher`` ``use_sim_time`` change it in the following way:
 


### PR DESCRIPTION
Updated paths for Gazebo world and robot spawning.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  N/A |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

* Updated the documentation section titled **“Add these two variables, which are needed for starting the Gazebo world and spawning the robot”**.
* Previously, this section listed:
  ```python
  default_model_path = os.path.join(pkg_share, 'src', 'description', 'sam_bot_description.sdf')
  default_rviz_config_path = os.path.join(pkg_share, 'rviz', 'config.rviz')
  ```
  However, these variables are **not related to Gazebo world launching or robot spawning**.  
  They are already defined in an earlier section of the documentation.
* Replaced them with the correct variables actually used for Gazebo world and robot spawning:
  ```python
  ros_gz_sim_share = get_package_share_directory('ros_gz_sim')
  gz_spawn_model_launch_source = os.path.join(ros_gz_sim_share, "launch", "gz_spawn_model.launch.py")
  ```
---

## Type of change
- [x] Documentation fix
- [ ] New feature
- [ ] Bug fix
- [ ] Refactor

---