### PR TITLE
Add missing /depth_camera/image_raw bridge entry in documentation

### DIFF
--- a/setup_guides/sensors/setup_sensors_gz.rst
+++ b/setup_guides/sensors/setup_sensors_gz.rst
@@ -288,6 +288,12 @@ We will also need to bridge the necessary sensor topics from Gazebo to ROS, add 
     gz_type_name: "gz.msgs.PointCloudPacked"
     direction: GZ_TO_ROS
 
+   - ros_topic_name: "/depth_camera/image_raw"
+     gz_topic_name: "/depth_camera/image"
+     ros_type_name: "sensor_msgs/msg/Image"
+     gz_type_name: "gz.msgs.Image"
+     direction: GZ_TO_ROS
+
 Build, Run and Verification
 ===========================
 


### PR DESCRIPTION
This PR updates the documentation section on updating `bridge_config.yaml` by adding the missing bridge configuration for the `/depth_camera/image_raw` topic.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  N/A |
| Does this PR contain AI-generated software? | No |
---

## Details

The tutorial includes a task to visualize the `/depth_camera/image_raw` topic in RViz2.  
However, without creating a ROS–Gazebo bridge for this topic, RViz2 cannot receive the image messages from Gazebo.

---