### PR TITLE
docs: Add wrap_around parameter documentation for RoundRobin BT node

### DIFF
--- a/configuration/packages/bt-plugins/controls/RoundRobin.rst
+++ b/configuration/packages/bt-plugins/controls/RoundRobin.rst
@@ -6,11 +6,25 @@ RoundRobin
 
 Custom control flow node used to create a round-robin behavior for children BT nodes.
 
+Input Ports
+-----------
+
+:wrap_around:
+
+  ============= =======
+  Type          Default
+  ============= =======
+  bool          false
+  ============= =======
+
+  Description
+    Controls wrap-around behavior. When ``false``, the node returns FAILURE instead of wrapping to the first child after all children have been attempted. When ``true``, the node wraps around to the first child and continues the round-robin behavior.
+
 Example
 -------
 
 .. code-block:: xml
 
-    <RoundRobin>
+    <RoundRobin wrap_around="false">
         <!--Add tree components here--->
     </RoundRobin>

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -492,3 +492,35 @@ Options to build with isolated tests
 In `PR #5516 <https://github.com/ros-navigation/navigation2/pull/5516>`_, we added an option to build with isolated tests.
 This allows users of ``rmw_zenoh_cpp`` to run the tests without needing to start a Zenoh router in a separate terminal.
 You can enable this by building with ``--cmake-args -DUSE_ISOLATED_TESTS=ON``.
+
+RoundRobin wrap_around Parameter
+--------------------------------
+
+`PR #5308 <https://github.com/ros-navigation/navigation2/pull/5308>`_ adds a new ``wrap_around`` parameter to the RoundRobin behavior tree control node.
+
+This parameter controls whether the RoundRobin node wraps around to its first child after the last one fails:
+
+- ``wrap_around=false`` (default): Node returns FAILURE instead of wrapping to first child
+- ``wrap_around=true``: Node wraps around to the first child and continues round-robin behavior
+
+**Breaking Change**: The default behavior has changed. Previously, RoundRobin would always wrap around. Now it defaults to ``wrap_around=false``, which means existing behavior trees will use the new non-wrap-around behavior unless explicitly configured.
+
+This change addresses issues where RoundRobin index can become misaligned with RecoveryNode retry counter when used in recovery sequences, ensuring each recovery action is performed once and only once.
+
+.. code-block:: xml
+
+    <!-- New default behavior (no wrap-around) -->
+    <RoundRobin wrap_around="false">
+        <Action_A/>
+        <Action_B/>
+        <Action_C/>
+    </RoundRobin>
+
+    <!-- Previous behavior (wrap-around) -->
+    <RoundRobin wrap_around="true">
+        <Action_A/>
+        <Action_B/>
+        <Action_C/>
+    </RoundRobin>
+
+For additional details regarding the ``RoundRobin`` please see the `RoundRobin configuration guide <../configuration/packages/bt-plugins/controls/RoundRobin.html>`_.


### PR DESCRIPTION
Add documentation for the new wrap_around parameter in RoundRobin BT node

## Summary
- Add wrap_around parameter to RoundRobin configuration documentation
- Add migration guide entry for the new parameter in Kilted.rst
- Document breaking change: default behavior changed to non-wrap-around

## Changes
1. Updated `configuration/packages/bt-plugins/controls/RoundRobin.rst` with parameter documentation
2. Added migration guide entry in `migration/Kilted.rst`

Implements documentation for https://github.com/ros-navigation/navigation2/pull/5308

🤖 Generated with [Claude Code](https://claude.ai/code)