### PR TITLE
Add grid value interpretation for inscribed inflated obstacles

### DIFF
--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -277,6 +277,17 @@ Costmap2D ROS Parameters
   Description
     Cost of unknown space if tracking it.
 
+:inscribed_obstacle_cost_value:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  int            99
+  ============== =======
+
+  Description
+    The OccupancyGrid values that represents ``INSCRIBED_INFLATED_OBSTACLE`` during costmap conversion operations.
+
 :update_frequency:
 
   ============== =======

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -524,3 +524,12 @@ This change addresses issues where RoundRobin index can become misaligned with R
     </RoundRobin>
 
 For additional details regarding the ``RoundRobin`` please see the `RoundRobin configuration guide <../configuration/packages/bt-plugins/controls/RoundRobin.html>`_.
+
+Configurable Inscribed Obstacle Cost Value for Costmap Conversion
+-----------------------------------------------------------------
+
+In `PR #5781 <https://github.com/ros-navigation/navigation2/pull/5781>`_, a new parameter inscribed_obstacle_cost_value is added to fix the issue where Costmap2DPublisher maps INSCRIBED_INFLATED_OBSTACLE (253) to value 99 in OccupancyGrid, but StaticLayer incorrectly converts it back to 251 instead of 253.
+
+Default value:
+
+- inscribed_obstacle_cost_value: 99


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | https://github.com/ros-navigation/navigation2/pull/5781 |
| Does this PR contain AI-generated software? | (No; Yes, and it is marked inline in the code) |
---

## Description of contribution in a few bullet points

<!--
* Updated the documentation to reflect corresponding changes in navigation2.
* Reorganised some sections for better clarity.
-->
