### PR TITLE
Add stamp_smoothed_velocity_with_smoothing_time parameter description to velocity_smoother node

### DIFF
--- a/configuration/packages/configuring-velocity-smoother.rst
+++ b/configuration/packages/configuring-velocity-smoother.rst
@@ -170,14 +170,7 @@ Velocity Smoother Parameters
   ============== =============================
 
   Description
-    Whether to interpolate the timestamps of the smoothed `geometery_msgs:msg::TwistStamped` cmd_vel message.
-
-    Default is ``false`` for backwards compatibility.
-
-    When ``true``, the timestamps of the sent cmd_vel message follow the rule:
-    ``cmd_vel_timestamp = cmd_vel_timestamp_of_last_received_command + (timestamp_now - timestamp_at_last_received_command)``
-
-    Note: This parameter only appears in Jazzy! Smoothing the timestamps is part of the default behavior in newer-than-jazzy distros.
+    Whether to interpolate the timestamps of the smoothed `geometery_msgs:msg::TwistStamped` cmd_vel message after the last command velocity received. Only available in Jazzy as a backport of the now-default behavior in Lyrical and newer. Default is ``false`` for backwards compatibility.
 
 :bond_heartbeat_period:
 


### PR DESCRIPTION
Added the description of a new parameter for timestamp interpolation of smoothed cmd_vel messages. This parameter only appears in ROS2 Jazzy and the behavior (when the parameter is true) is the default behavior in newer-than-jazzy distributions.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | [Navigation2: #5857](https://github.com/ros-navigation/navigation2/issues/5857) |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

* Updated the documentation to reflect corresponding changes in navigation2 (see https://github.com/ros-navigation/navigation2/pull/5858)
