### PR TITLE
docs(amcl): document random_seed parameter

### DIFF
--- a/configuration/packages/configuring-amcl.rst
+++ b/configuration/packages/configuring-amcl.rst
@@ -276,6 +276,20 @@ Parameters
   Description
     Particle filter population density. 2.33 is the 99% percentile.
 
+:random_seed:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  int            -1
+  ============== =============================
+
+  Description
+    Seed for the particle filter RNG.
+
+    - ``random_seed >= 0``: seed the RNG with the provided value (repeatable runs).
+    - ``random_seed < 0`` (default): seed the RNG from time (preserves historical behavior).
+
 :recovery_alpha_fast:
 
   ============== =============================
@@ -540,6 +554,7 @@ Example
         odom_frame_id: "odom"
         pf_err: 0.05
         pf_z: 0.99
+        random_seed: -1
         recovery_alpha_fast: 0.0
         recovery_alpha_slow: 0.0
         resample_interval: 1


### PR DESCRIPTION
This documents the `random_seed` parameter in the AMCL configuration guide and updates the example YAML.

Related: ros-navigation/navigation2#5856
Requested in review: https://github.com/ros-navigation/navigation2/pull/5856/files#r2683965698