### PR TITLE
Remove observation sources in the global level

### DIFF
--- a/configuration/packages/configuring-costmaps.rst
+++ b/configuration/packages/configuring-costmaps.rst
@@ -123,17 +123,6 @@ Costmap2D ROS Parameters
   Description
     The height of map, allows to avoid rviz visualization flickering at -0.008
 
-:observation_sources:
-
-  ============== =======
-  Type           Default
-  -------------- -------
-  string         ""
-  ============== =======
-
-  Description
-    List of sources of sensors as a string, to be used if not specified in plugin specific configurations. Ex. "static_layer stvl_layer"
-
 :origin_x:
 
   ============== =======


### PR DESCRIPTION
Fixes https://github.com/ros-navigation/docs.nav2.org/issues/851, I believe this should be removed because it only exists in the plugin level.


We declare the parameter here but never get
https://github.com/ros-navigation/navigation2/blob/018dca9a43793b3944c3058526589530c4148034/nav2_costmap_2d/src/costmap_2d_ros.cpp#L123