### PR TITLE
update vector object server docs for new parameter enforce_global_frame_id

### DIFF
--- a/configuration/packages/map_server/configuring-vector-object-server.rst
+++ b/configuration/packages/map_server/configuring-vector-object-server.rst
@@ -96,6 +96,17 @@ Parameters
   Description:
     The name of the coordinate frame where the map is being published at.
 
+:enforce_global_frame_id:
+
+  ============== =============================
+  Type           Default
+  -------------- -----------------------------
+  bool           false
+  ============== =============================
+
+  Description:
+    Enforce the use of the global frame ID for all shapes. Any shape with a non-empty frame ID, different than the global frame ID, will lead to failure. This will also disable the creation of the TF listener. 
+    
 :resolution:
 
   ============== =============================
@@ -288,6 +299,7 @@ Here is an example of configuration YAML for the Vector Object server:
       ros__parameters:
         map_topic: "vo_map"
         global_frame_id: "map"
+        enforce_global_frame_id: False
         resolution: 0.05
         default_value: -1
         overlay_type: 0

--- a/configuration/packages/map_server/configuring-vector-object-server.rst
+++ b/configuration/packages/map_server/configuring-vector-object-server.rst
@@ -105,8 +105,8 @@ Parameters
   ============== =============================
 
   Description:
-    Enforce the use of the global frame ID for all shapes. Any shape with a non-empty frame ID, different than the global frame ID, will lead to failure. This will also disable the creation of the TF listener. 
-    
+    Enforce the use of the global frame ID for all shapes. Any shape with a non-empty frame ID, different than the global frame ID, will lead to failure. This will also disable the creation of the TF listener.
+
 :resolution:
 
   ============== =============================


### PR DESCRIPTION
Added documentation for new parameter `enforce_global_frame_id` in the Vector Object Server.

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

<!--
* Updated the documentation to reflect corresponding changes in navigation2.
* Reorganised some sections for better clarity.
-->
The implementation is in https://github.com/ros-navigation/navigation2/pull/6077.
