### PR TITLE
Update a missing github link in dev container guide

### DIFF
--- a/development_guides/devcontainer_docs/devcontainer_guide.md
+++ b/development_guides/devcontainer_docs/devcontainer_guide.md
@@ -144,7 +144,7 @@ While using the dev container, try and keep in mind the lifecycle of the contain
 :::{important}
 This is particularly important when the host machine is inherently ephemeral as well, as the case may be when using cloud based environments such as Codespaces, so be sure to commit and push local changes to a remote repository:
 
-- [The codespace lifecycle](https://docs.github.com/en/codespaces/getting-started/the-codespace-lifecycle)
+- [The codespace lifecycle](https://docs.github.com/en/codespaces/about-codespaces/understanding-the-codespace-lifecycle)
   - Maintain your data throughout the entire codespace lifecycle
 :::
 


### PR DESCRIPTION
On dev container doc [page](https://docs.nav2.org/development_guides/devcontainer_docs/devcontainer_guide.html#lifecycle), the URL with text `The codespace lifecycle` leads to a missing page. Replaced it with the new page.

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points
* Replaced the old URL
<!--
* Updated the documentation to reflect corresponding changes in navigation2.
* Reorganised some sections for better clarity.
-->
