### PR TITLE
Specify behavior of RecoveryNode on recovery failure

### DIFF
--- a/configuration/packages/bt-plugins/controls/RecoveryNode.rst
+++ b/configuration/packages/bt-plugins/controls/RecoveryNode.rst
@@ -7,6 +7,7 @@ The RecoveryNode is a control flow node with two children.
 It returns SUCCESS if and only if the first child returns SUCCESS.
 The second child will be executed only if the first child returns FAILURE.
 If the second child SUCCEEDS, then the first child will be executed again.
+If the second child returns FAILURE, the RecoveryNode returns FAILURE as well.
 The user can specify how many times the recovery actions should be taken before returning FAILURE.
 In nav2, the RecoveryNode is included in Behavior Trees to implement recovery actions upon failures.
 


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A |
| Does this PR contain AI-generated software? | No |
---

## Description of contribution in a few bullet points

* Added description that RecoveryNode returns FAILURE if the second (recovery) child fails (instead of, for example, retrying the recovery). This seems to be the implemented behavior: https://github.com/ros-navigation/navigation2/blob/d1b17904ec56ec246f7175d3d6228b81854cf0f1/nav2_behavior_tree/plugins/control/recovery_node.cpp#L105-L108