### PR TITLE
Update TruncatePathLocal docs for robot_base_frame rename

### DIFF
--- a/configuration/packages/bt-plugins/actions/RemovePassedGoals.rst
+++ b/configuration/packages/bt-plugins/actions/RemovePassedGoals.rst
@@ -25,11 +25,11 @@ Input Ports
   ====== ===========
   Type   Default
   ------ -----------
-  string "base_link"
+  string N/A
   ====== ===========
 
   Description
-    Robot base frame.
+    Robot base frame. If not provided, uses the BT Navigator's ``robot_base_frame`` setting automatically.
 
 :input_goals:
 

--- a/configuration/packages/bt-plugins/actions/TruncatePathLocal.rst
+++ b/configuration/packages/bt-plugins/actions/TruncatePathLocal.rst
@@ -41,16 +41,16 @@ Input Ports
   Description
       The trimming distance in backward direction.
 
-:robot_frame:
+:robot_base_frame:
 
   ====== ===========
   Type   Default
   ------ -----------
-  string "base_link"
+  string N/A
   ====== ===========
 
   Description
-      Robot base frame id.
+      Robot base frame id. If not provided, uses the BT Navigator's ``robot_base_frame`` setting automatically.
 
 :transform_tolerance:
 

--- a/configuration/packages/bt-plugins/conditions/DistanceTraveled.rst
+++ b/configuration/packages/bt-plugins/conditions/DistanceTraveled.rst
@@ -40,22 +40,22 @@ Input Ports
   ====== =======
   Type   Default
   ------ -------
-  string "map"
+  string N/A
   ====== =======
 
   Description
-    Reference frame.
+    Reference frame. If not provided, uses the BT Navigator's ``global_frame`` setting automatically.
 
 :robot_base_frame:
 
   ====== ===========
   Type   Default
   ------ -----------
-  string "base_link"
+  string N/A
   ====== ===========
 
   Description
-    Robot base frame.
+    Robot base frame. If not provided, uses the BT Navigator's ``robot_base_frame`` setting automatically.
 
 Example
 -------

--- a/migration/Kilted.rst
+++ b/migration/Kilted.rst
@@ -1031,3 +1031,17 @@ The plot shows the path of a vehicle with 600 ms steering delay. Without delay c
 SpeedFilter path lookahead
 --------------------------
 `PR #6150 <https://github.com/ros-navigation/navigation2/pull/6150>`_ adds an optional path-lookahead mode to the SpeedFilter plugin, enabled via the ``enable_path_lookahead`` parameter (default disabled). When enabled, the filter looks ahead along the planned path and applies the strictest speed limit found within a velocity-dependent window, allowing the robot to decelerate before entering a speed-restricted zone. The default behavior of speed limits being applied only at the robot's current pose is unchanged when the parameter ``enable_path_lookahead`` is left disabled. See the :ref:`speed_filter` configuration page for the new parameters that control the lookahead behavior.
+
+TruncatePathLocal BT Node: robot_frame renamed to robot_base_frame
+------------------------------------------------------------------
+`PR #6242 <https://github.com/ros-navigation/navigation2/pull/6242>`_ renames the ``robot_frame`` input port to ``robot_base_frame`` to align with Nav2 naming conventions. The node now uses ``deconflictPortAndParamFrame()`` to respect the ``robot_base_frame`` parameter from the BT Navigator config when the port is omitted, matching the behavior of other BT nodes like ``GetCurrentPose`` and ``GoalReached``.
+
+Behavior trees using ``TruncatePathLocal`` with the old port name will need to update:
+
+.. code-block:: xml
+
+   <!-- Before -->
+   <TruncatePathLocal robot_frame="base_link" ... />
+
+   <!-- After -->
+   <TruncatePathLocal robot_base_frame="base_link" ... />


### PR DESCRIPTION
## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses | ros-navigation/navigation2#6226, ros-navigation/navigation2#6242 |
| Does this PR contain AI-generated software? | No |

---

## Description of contribution in a few bullet points

* Updated **TruncatePathLocal** docs: renamed `robot_frame` → `robot_base_frame`, default changed to N/A
* Updated **RemovePassedGoals** docs: `robot_base_frame` default changed from `"base_link"` to N/A  
* Updated **DistanceTraveled** docs: `global_frame` and `robot_base_frame` defaults changed to N/A
* Added descriptions noting these ports fall back to BT Navigator parameters when not provided
* Added migration guide entry for TruncatePathLocal port rename (the only breaking change)