### PR TITLE
Document NavFn max_cycles_factor

### DIFF
--- a/configuration/packages/configuring-navfn.rst
+++ b/configuration/packages/configuring-navfn.rst
@@ -41,12 +41,12 @@ Parameters
   ============== =======
   Type           Default
   -------------- -------
-  double         4.0
+  int            4
   ============== =======
 
   Description
-    Factor multiplied by the largest costmap dimension, in cells, and rounded up to determine the maximum number of path extraction cycles.
-    For example, a 500 by 400 cell costmap with a factor of 4.0 allows 2000 path extraction cycles.
+    Integer factor multiplied by the largest costmap dimension, in cells, to determine the maximum number of path extraction cycles.
+    For example, a 500 by 400 cell costmap with a factor of 4 allows 2000 path extraction cycles.
     Increase this value for maps with long or winding paths that may exceed the default cycle limit.
     Higher values allow more path extraction work before failure and may increase planning time when a path cannot be extracted.
 
@@ -95,4 +95,4 @@ Example
           use_astar: True
           allow_unknown: True
           tolerance: 1.0
-          max_cycles_factor: 4.0
+          max_cycles_factor: 4

--- a/configuration/packages/configuring-navfn.rst
+++ b/configuration/packages/configuring-navfn.rst
@@ -36,6 +36,20 @@ Parameters
   Description
     Whether to use A*. If false, uses Dijkstra's expansion.
 
+:``<name>``.max_cycles_factor:
+
+  ============== =======
+  Type           Default
+  -------------- -------
+  double         4.0
+  ============== =======
+
+  Description
+    Factor multiplied by the largest costmap dimension, in cells, and rounded up to determine the maximum number of path extraction cycles.
+    For example, a 500 by 400 cell costmap with a factor of 4.0 allows 2000 path extraction cycles.
+    Increase this value for maps with long or winding paths that may exceed the default cycle limit.
+    Higher values allow more path extraction work before failure and may increase planning time when a path cannot be extracted.
+
 :``<name>``.allow_unknown:
 
   ==== =======
@@ -81,3 +95,4 @@ Example
           use_astar: True
           allow_unknown: True
           tolerance: 1.0
+          max_cycles_factor: 4.0


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | ros-navigation/navigation2#6308 |
| Does this PR contain AI-generated software? | No; this is a documentation-only change. The wording was drafted with AI assistance and reviewed by me. |
---

## Description of contribution in a few bullet points

<!--
* Updated the documentation to reflect corresponding changes in navigation2.
* Reorganised some sections for better clarity.
-->

* Document the new integer `max_cycles_factor` parameter introduced by ros-navigation/navigation2#6308.
* Explain how the path extraction cycle limit is calculated from the largest costmap dimension.
* Add a concrete 500 by 400 cell costmap example using the default factor of `4`.
* Add `max_cycles_factor: 4` to the NavFn YAML configuration example.
