### PR TITLE
Update docs for PR#6307 (commander API)

### DIFF
--- a/commander_api/index.rst
+++ b/commander_api/index.rst
@@ -68,8 +68,9 @@ New as of September 2023: the simple navigator constructor will accept a `namesp
 | goToPose(pose, behavior_tree='')      | Requests the robot to drive to a pose (``PoseStamped``).                   |
 +---------------------------------------+----------------------------------------------------------------------------+
 | followWaypoints(poses,                | Requests the robot to follow a set of waypoints (list of ``PoseStamped``), |
-| number_of_loops=0,                    | starting at ``goal_index`` and repeating ``number_of_loops`` times after   |
-| goal_index=0)                         | the first pass (0 runs it once).                                           |
+| number_of_loops=0,                    | starting at ``goal_index`` (default ``0``) and repeating                   |
+| goal_index=0)                         | ``number_of_loops`` times after the first pass (default ``0``, runs once). |
+|                                       | This will execute the chosen ``TaskExecutor`` plugin at each pose.         |
 +---------------------------------------+----------------------------------------------------------------------------+
 | followPath(path, controller_id='',    | Requests the robot to follow a path from a starting to a goal              |
 | goal_checker_id='',                   | ``PoseStamped``, ``nav_msgs/Path``.                                        |

--- a/commander_api/index.rst
+++ b/commander_api/index.rst
@@ -68,10 +68,8 @@ New as of September 2023: the simple navigator constructor will accept a `namesp
 | goToPose(pose, behavior_tree='')      | Requests the robot to drive to a pose (``PoseStamped``).                   |
 +---------------------------------------+----------------------------------------------------------------------------+
 | followWaypoints(poses,                | Requests the robot to follow a set of waypoints (list of ``PoseStamped``), |
-| number_of_loops=0,                    | repeating the full set ``number_of_loops`` additional times after the      |
-| goal_index=0)                         | first pass (0 runs it once), starting from ``goal_index`` into ``poses``   |
-|                                       | rather than the beginning. This will execute the chosen ``TaskExecutor``   |
-|                                       | plugin at each pose.                                                       |
+| number_of_loops=0,                    | starting at ``goal_index`` and repeating ``number_of_loops`` times after   |
+| goal_index=0)                         | the first pass (0 runs it once).                                           |
 +---------------------------------------+----------------------------------------------------------------------------+
 | followPath(path, controller_id='',    | Requests the robot to follow a path from a starting to a goal              |
 | goal_checker_id='',                   | ``PoseStamped``, ``nav_msgs/Path``.                                        |

--- a/commander_api/index.rst
+++ b/commander_api/index.rst
@@ -67,8 +67,11 @@ New as of September 2023: the simple navigator constructor will accept a `namesp
 +---------------------------------------+----------------------------------------------------------------------------+
 | goToPose(pose, behavior_tree='')      | Requests the robot to drive to a pose (``PoseStamped``).                   |
 +---------------------------------------+----------------------------------------------------------------------------+
-| followWaypoints(poses)                | Requests the robot to follow a set of waypoints (list of ``PoseStamped``). |
-|                                       | This will execute the chosen ``TaskExecutor`` plugin at each pose.         |
+| followWaypoints(poses,                | Requests the robot to follow a set of waypoints (list of ``PoseStamped``), |
+| number_of_loops=0,                    | repeating the full set ``number_of_loops`` additional times after the      |
+| goal_index=0)                         | first pass (0 runs it once), starting from ``goal_index`` into ``poses``   |
+|                                       | rather than the beginning. This will execute the chosen ``TaskExecutor``   |
+|                                       | plugin at each pose.                                                       |
 +---------------------------------------+----------------------------------------------------------------------------+
 | followPath(path, controller_id='',    | Requests the robot to follow a path from a starting to a goal              |
 | goal_checker_id='',                   | ``PoseStamped``, ``nav_msgs/Path``.                                        |


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | Doc update for [PR #6307](https://github.com/ros-navigation/navigation2/pull/6307) in navigation2 |
| Does this PR contain AI-generated software? | No, but used AI for formatting the table |
---

## Description of contribution in a few bullet points

Updated the commander API table with the followWaypoints function's new optional arguments, described in [PR #6307](https://github.com/ros-navigation/navigation2/pull/6307) in navigation2
